### PR TITLE
Hotfix 코드 제출 시 결과가 나올 때까지 대기할 수 있도록 loader 로직 수정

### DIFF
--- a/scripts/baekjoon/baekjoon.js
+++ b/scripts/baekjoon/baekjoon.js
@@ -26,16 +26,14 @@ function startLoader() {
       const data = table[0];
       if (data.hasOwnProperty('username') && data.hasOwnProperty('result')) {
         const { username, result } = data;
-        if (username !== findUsername() || result === '틀렸습니다') {
-          stopLoader();
-          return;
-        }
+        stopLoader();
+
         if (username === findUsername() && result === '맞았습니다!!') {
           if (debug) console.log('풀이가 맞았습니다. 업로드를 시작합니다.');
-          stopLoader();
           const bojData = await findData();
           await beginUpload(bojData);
         }
+        else return;
       }
     }
   }, 2000);

--- a/scripts/baekjoon/parsing.js
+++ b/scripts/baekjoon/parsing.js
@@ -15,17 +15,21 @@
 */
 async function findData(data) {
   try {
-    if (isNull(data)) data = findFromResultTable();
-    const { 
-      title, 
-      level, 
-      code, 
-      problemDescription, 
-      directory, 
-      message, 
-      category, 
-      fileName, 
-      readme 
+    if (isNull(data)) {
+      const table = filter(findFromResultTable(), 'result', '맞았습니다!!');
+      if (isEmpty(table)) return null;
+      data = selectBestSubmissionList(table)[0];
+    }
+    const {
+      title,
+      level,
+      code,
+      problemDescription,
+      directory,
+      message,
+      category,
+      fileName,
+      readme
     } = await makeDetailMessageAndReadme(data.problemId, data.submissionId, data.language, data.memory, data.runtime);
     return {
       meta: {
@@ -139,7 +143,7 @@ function parsingResultTableList(doc) {
     for (let j = 0; j < headers.length; j++) {
       obj[headers[j]] = cells[j];
     }
-    if (obj.result === '맞았습니다!!') list.push(obj);
+    list.push(obj);
   }
   if (debug) console.log('TableList', list);
   return list;
@@ -161,10 +165,7 @@ function findFromResultTable() {
   if (!isExistResultTable()) {
     if (debug) console.log('Result table not found');
   }
-  const resultList = parsingResultTableList(document);
-  if (resultList.length === 0) return;
-  // const row = resultList[0];
-  return selectBestSubmissionList(resultList)[0];
+  return parsingResultTableList(document);
 }
 
 /*

--- a/scripts/baekjoon/util.js
+++ b/scripts/baekjoon/util.js
@@ -110,27 +110,29 @@ function convertResultTableHeader(header) {
   }
 }
 
-function updateStatsPostUpload(bojData, sha, type, cb = undefined) {
+/** github에 업로드한 파일의 sha 정보를 업데이트 합니다.
+ * @param {object} bojData - 문제 정보
+ * @param {string} sha - 업로드 파일 sha 정보
+ * @param {enum<CommitType>} type - 업로드 파일의 타입
+ * @param {function} cb - 저장을 완료한 후 호출할 콜백함수
+ * @returns {void}
+ */
+function updateStatsPostUpload(bojData, sha, type, cb) {
   getStats().then((stats) => {
-    if (stats === null || stats === {} || stats === undefined) {
-      // create stats object
-      stats = {};
-      stats.version = '1.0.2';
-      stats.submission = {};
+    if (isEmpty(stats)) {
+      stats = { version: getVersion(), submissions: {} };
     }
 
     const filePath = bojData.meta.problemId + bojData.meta.problemId + bojData.meta.language;
-    const { submissionId } = bojData.submission;
 
     if (isNull(stats.submission[filePath])) {
       stats.submission[filePath] = {};
     }
 
-    stats.submission[filePath].submissionId = submissionId;
-    stats.submission[filePath][type] = sha; // update sha key.
+    stats.submission[filePath] = { ...stats.submission[filePath], ...{ submissionId: bojData.submission.submissionId, [type]: sha } };
     saveStats(stats).then(() => {
       if (debug) console.log(`Successfully committed ${bojData.meta.fileName} to github`);
-      if (cb !== undefined) cb();
+      if (typeof cb === 'function') cb();
     });
   });
 }

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -11,7 +11,7 @@ function getVersion() {
  * @returns {boolean} - 존재하면 true, 존재하지 않으면 false
  */
 function elementExists(element) {
-  return element !== undefined && element !== null && element.length > 0;
+  return element !== undefined && element !== null && element.hasOwnProperty('length') && element.length > 0;
 }
 
 /**
@@ -29,7 +29,7 @@ function isNull(value) {
  * @returns {boolean} - 비어있으면 true, 비어있지 않으면 false
  */
 function isEmpty(value) {
-  return isNull(value) || value === '' || value === [] || value === {};
+  return isNull(value) || (value.hasOwnProperty('length') && value.length === 0);
 }
 
 /** 객체 또는 배열의 모든 요소를 재귀적으로 순회하여 값이 비어있지 않은지 체크합니다.
@@ -202,4 +202,16 @@ function maxValuesGroupBykey(arr, key, compare) {
     result.push(maxValue);
   }
   return result;
+}
+
+/** 배열 내의 key:val 값을 가지고 있는 요소만을 반환합니다.
+ * @param {array} arr - array to be filtered
+ * @param {string} key - key to filter
+ * @param {string} val - value to filter
+ * @returns {array} - filtered array
+ */
+function filter(arr, key, val) {
+  return arr.filter(function (item) {
+    return item[key] === val;
+  });
 }


### PR DESCRIPTION
### 개요
코드 제출 시 결과가 나올 때까지 대기할 수 있도록 loader 로직 수정

### 작업사항
- Hotfix findData 함수 내의 맞은 결과만을 가져가도록 filter 함수 추가
- Refactor 일부 함수 내 if문 처리(객체가 null 일 때)에 대한 최적화 처리

### 변경로직
- Hotfix findData 함수 내의 맞은 결과만을 가져가도록 filter 함수 추가
  - startLoader 함수 내의 findFromResultTable 함수를 통해 가져온 테이블을 검증하는 과정 추가
  - findFromResultTable  함수 내에서 최적의 값만을 선택하는 과정 삭제
  - parsingResultTableList 함수 내에서 '맞았습니다!!' 결과만을 선택하는 과정 삭제
  - findData 함수 내의 최적의 테이블 값을 가져오도록 조건 수정
- Refactor 일부 함수 내 if문 처리(객체가 null 일 때)에 대한 최적화 처리
  - beginUpload 함수 내의 객체 조건 체크 if문 로직 최적화
  - util 에서 elementExists,  isEmpty 함수 수정 및 filter 함수 추가

### 확인사항
내 제출 목록에서 문제 없이 제출 되는지 확인 (이상없음)

### 기타
없음