### PR TITLE
Fix 새로운 문제의 결과가 늦게 나와도 Loader가 중지되지 않도록 중지 시점 변경

### DIFF
--- a/scripts/baekjoon/baekjoon.js
+++ b/scripts/baekjoon/baekjoon.js
@@ -27,14 +27,12 @@ function startLoader() {
       const data = table[0];
       if (data.hasOwnProperty('username') && data.hasOwnProperty('result')) {
         const { username, result } = data;
-        stopLoader();
-
         if (username === findUsername() && result === '맞았습니다!!') {
+          stopLoader();
           if (debug) console.log('풀이가 맞았습니다. 업로드를 시작합니다.');
           const bojData = await findData();
           await beginUpload(bojData);
         }
-        else return;
       }
     }
   }, 2000);


### PR DESCRIPTION
### 개요
코드 제출 시 결과가 나올 때까지 대기할 수 있도록 loader 로직 수정

### 작업사항
- Fix 새로운 문제의 결과가 늦게 나와도 Loader가 중지되지 않도록 중지 시점 변경

### 변경로직
- stopLoader() 함수를 호출하는 시점을 더 이후로 이동

### 확인사항
결과가 늦게 나오는 문제들이 문제 없이 제출 되는지 확인 (이상없음)

### 기타
![image](https://user-images.githubusercontent.com/31976959/149923484-5108e7fe-3b8c-44ae-ad22-c57b4d55752f.png)
> Loader 내의 로직이 단 한번 사이클만 작동하는 것을 확인 -> 논리 로직 이상 확인