### PR TITLE
Fix 기존 백준 문제 설명과 입출력에 대한 설명을 불러올 수 있도록 수정

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "백준허브(BaekjoonHub)",
   "description": "Automatically integrate your BOJ submissions to GitHub",
   "homepage_url": "https://github.com/BaekjoonHub/BaekjoonHub",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": "flaxinger",
   "browser_action": {
     "default_icon": "assets/thumbnail.png",

--- a/scripts/baekjoon/baekjoon.js
+++ b/scripts/baekjoon/baekjoon.js
@@ -1,5 +1,5 @@
 // Set to true to enable console log
-const debug = true;
+const debug = false;
 
 /* 
   문제 제출 맞음 여부를 확인하는 함수

--- a/scripts/baekjoon/baekjoon.js
+++ b/scripts/baekjoon/baekjoon.js
@@ -1,5 +1,6 @@
 // Set to true to enable console log
 const debug = false;
+
 /* 
   문제 제출 맞음 여부를 확인하는 함수
   2초마다 문제를 파싱하여 확인
@@ -15,6 +16,7 @@ const username = findUsername();
 if (!isNull(username)) {
   if (currentUrl.includes('status?') && currentUrl.includes(`user_id=${username}`)) startLoader();
   else if (currentUrl.includes('/source/') && currentUrl.includes('extension=BaekjoonHub')) parseLoader();
+  else if (currentUrl.match(/\/problem\/\d+/) !== null) parseProblemDescription();
   else if (currentUrl.includes('.net/user')) {
     getStats().then((stats) => {
       if (!isEmpty(stats.version) && stats.version === getVersion()) {

--- a/scripts/baekjoon/baekjoon.js
+++ b/scripts/baekjoon/baekjoon.js
@@ -1,5 +1,5 @@
 // Set to true to enable console log
-const debug = false;
+const debug = true;
 
 /* 
   문제 제출 맞음 여부를 확인하는 함수

--- a/scripts/baekjoon/storage.js
+++ b/scripts/baekjoon/storage.js
@@ -5,7 +5,7 @@ async function updateProblemsFromStats(problem) {
     problem_description: problem.problem_description,
     problem_input: problem.problem_input,
     problem_output: problem.problem_output,
-    save_date: new Date().getTime()
+    save_date: Date.now()
   };
   if(debug) console.log('problem date', stats.problems[problem.problemId].save_date);
   if(debug) console.log('stats', stats);
@@ -25,18 +25,18 @@ async function getProblemsfromStats(problemId) {
 async function deleteOldProblemDescriptions(){
   const stats = await getStats();
   if(!stats.last_check_date){
-    stats.last_check_date = new Date().getTime();
+    stats.last_check_date = Date.now();
     await saveStats(stats);
     if(debug) console.log("Initialized stats date", stats.last_check_date);
     return;
   }
   else{
-    let date_yesterday = new Date() - 86400000; // 24 * 60 * 60 * 1000 = 86400000 ms = 1day
+    let date_yesterday = Date.now() - 86400000; // 24 * 60 * 60 * 1000 = 86400000 ms = 1day
     if(debug) console.log('금일 로컬스토리지 정리를 완료하였습니다.');
     if(date_yesterday<stats.last_check_date) return;
   }
   // 1 주가 지난 문제 내용은 삭제
-  let date_week_ago = new Date()- 7* 86400000;
+  let date_week_ago = Date.now() - 7* 86400000;
   if(debug) console.log('stats before deletion', stats);
   if(debug) console.log('date a week ago', date_week_ago);
   for(const [key, value] of Object.entries(stats.problems)){
@@ -52,7 +52,7 @@ async function deleteOldProblemDescriptions(){
       }
     }
   }
-  stats.last_check_date = new Date().getTime();
+  stats.last_check_date = Date.now();
   if(debug) console.log('stats after deletion', stats);
   await saveStats(stats);
 }

--- a/scripts/baekjoon/storage.js
+++ b/scripts/baekjoon/storage.js
@@ -1,0 +1,16 @@
+async function updateProblemsFromStats(problem) {
+  const stats = await getStats();
+  stats.problems[problem.problemId] = {
+    problem_description: problem.problem_description,
+    problem_input: problem.problem_input,
+    problem_output: problem.problem_output,
+  };
+  console.log("stats", stats);
+  await saveStats(stats);
+}
+
+async function getProblemsfromStats(problemId) {
+  const stats = await getStats();
+  console.log("stats.problems[problemId]", stats.problems[problemId]);
+  return stats.problems[problemId] ?? {};
+}

--- a/scripts/baekjoon/storage.js
+++ b/scripts/baekjoon/storage.js
@@ -38,7 +38,7 @@ async function deleteOldProblemDescriptions(){
   // 1 주가 지난 문제 내용은 삭제
   let date_week_ago = new Date()- 7* 86400000;
   if(debug) console.log('stats before deletion', stats);
-  console.log('date a week ago', date_week_ago);
+  if(debug) console.log('date a week ago', date_week_ago);
   for(const [key, value] of Object.entries(stats.problems)){
     // 무한 방치를 막기 위해 저장일자가 null이면 삭제
     if(!value || !value.save_date){

--- a/scripts/baekjoon/storage.js
+++ b/scripts/baekjoon/storage.js
@@ -1,11 +1,14 @@
 async function updateProblemsFromStats(problem) {
+  await deleteOldProblemDescriptions();
   const stats = await getStats();
   stats.problems[problem.problemId] = {
     problem_description: problem.problem_description,
     problem_input: problem.problem_input,
     problem_output: problem.problem_output,
+    save_date: new Date().getTime()
   };
-  console.log("stats", stats);
+  if(debug) console.log('problem date', stats.problems[problem.problemId].save_date);
+  if(debug) console.log('stats', stats);
   await saveStats(stats);
 }
 
@@ -13,4 +16,43 @@ async function getProblemsfromStats(problemId) {
   const stats = await getStats();
   console.log("stats.problems[problemId]", stats.problems[problemId]);
   return stats.problems[problemId] ?? {};
+}
+
+/**
+ * Local Storage 정리 함수
+ * 1주가 넘은 문제 요약 삭제
+ */
+async function deleteOldProblemDescriptions(){
+  const stats = await getStats();
+  if(!stats.last_check_date){
+    stats.last_check_date = new Date().getTime();
+    await saveStats(stats);
+    if(debug) console.log("Initialized stats date", stats.last_check_date);
+    return;
+  }
+  else{
+    let date_yesterday = new Date() - 86400000; // 24 * 60 * 60 * 1000 = 86400000 ms = 1day
+    if(debug) console.log('금일 로컬스토리지 정리를 완료하였습니다.');
+    if(date_yesterday<stats.last_check_date) return;
+  }
+  // 1 주가 지난 문제 내용은 삭제
+  let date_week_ago = new Date()- 7* 86400000;
+  if(debug) console.log('stats before deletion', stats);
+  console.log('date a week ago', date_week_ago);
+  for(const [key, value] of Object.entries(stats.problems)){
+    // 무한 방치를 막기 위해 저장일자가 null이면 삭제
+    if(!value || !value.save_date){
+      delete stats.problems[key]; 
+    }
+    else{
+      let problem_save_date = new Date(value.save_date);
+      // 1주가 지난 코드는 삭제
+      if(date_week_ago > problem_save_date){
+        delete stats.problems[key];
+      }
+    }
+  }
+  stats.last_check_date = new Date().getTime();
+  if(debug) console.log('stats after deletion', stats);
+  await saveStats(stats);
 }

--- a/scripts/baekjoon/util.js
+++ b/scripts/baekjoon/util.js
@@ -86,6 +86,8 @@ function startUploadCountDown() {
  * 4. 위의 요소가 모두 같은 경우 제출한 요소(submissionId)의 그 차이 값의 역을 반환합니다.
  * */
 function compareSubmission(a, b) {
+  // prettier-ignore-start
+  /* eslint-disable */
   return a.runtime === b.runtime
           ? a.memory === b.memory
             ? a.codeLength === b.codeLength
@@ -94,6 +96,8 @@ function compareSubmission(a, b) {
             : a.memory - b.memory
           : a.runtime - b.runtime
   ;
+  /* eslint-enable */
+  // prettier-ignore-end
 }
 
 /**
@@ -200,4 +204,12 @@ function incMultiLoader(num) {
 
 function MultiloaderUpToDate() {
   multiloader.wrap.innerHTML = 'Up To Date';
+}
+
+function convertImageTagAbsoluteURL(doc = document) {
+  // img tag replace Relative URL to Absolute URL.
+  Array.from(doc.getElementsByTagName('img'), (x) => {
+    x.setAttribute('src', x.currentSrc);
+    return x;
+  });
 }

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -8,13 +8,13 @@ chrome.storage.local.get('isSync', (data) => {
       });
     });
     chrome.storage.local.set({ isSync: true }, (data) => {
-      // if (debug) 
+      // if (debug)
       console.log('BaekjoonHub Synced to local values');
     });
   } else {
-    // if (debug) 
+    // if (debug)
     // console.log('Upload Completed. Local Storage status:', data);
-    // if (debug) 
+    // if (debug)
     console.log('BaekjoonHub Local storage already synced!');
   }
 });
@@ -28,6 +28,7 @@ getStats().then((stats) => {
   if (isNull(stats.version)) stats.version = '0.0.0';
   if (isNull(stats.branches) || stats.version !== getVersion()) stats.branches = {};
   if (isNull(stats.submission) || stats.version !== getVersion()) stats.submission = {};
+  if (isNull(stats.problems) || stats.version !== getVersion()) stats.problems = {};
   saveStats(stats);
 });
 


### PR DESCRIPTION
- 기존에 핫픽스 시점으로 주석으로된 대부분의 코드를 삭제하였습니다.
- 문제 페이지에 접근한 경우 이를 파싱하여 로컬 스토리지에 저장합니다.
- 문제 업로드 시, 위의 파싱한 로컬 스토리지의 내용을 가져와 문제 설명을 만들 때 사용합니다.
(이때에 파싱한 데이터가 존재하지 않는다면 문제 설명이 빈 상태로 README.md 내용을 생성합니다)