### PR TITLE
Fix 에러 발생 시 에러 모달에 코드 스택 내용을 추가 및 자잘한 오류 수정

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -32,13 +32,6 @@ chrome.storage.local.get('BaekjoonHub_token', (data) => {
               $('#commit_mode').show();
               /* Get problem stats and repo link */
               chrome.storage.local.get(['stats', 'BaekjoonHub_hook'], (data3) => {
-                const { stats } = data3;
-                if (stats && stats.solved) {
-                  $('#p_solved').text(stats.solved);
-                  $('#p_solved_easy').text(stats.easy);
-                  $('#p_solved_medium').text(stats.medium);
-                  $('#p_solved_hard').text(stats.hard);
-                }
                 const BaekjoonHubHook = data3.BaekjoonHub_hook;
                 if (BaekjoonHubHook) {
                   $('#repo_url').html(`Your Repo: <a target="blank" style="color: cadetblue !important;" href="https://github.com/${BaekjoonHubHook}">${BaekjoonHubHook}</a>`);

--- a/scripts/authorize.js
+++ b/scripts/authorize.js
@@ -29,7 +29,7 @@ const localAuth = {
       });
     } else {
       // eslint-disable-next-line
-      const accessCode = url.match(/\?code=(.+)/);
+      const accessCode = url.match(/\?code=([\w\/\-]+)/);
       if (accessCode) {
         this.requestToken(accessCode[1]);
       }

--- a/scripts/authorize.js
+++ b/scripts/authorize.js
@@ -29,7 +29,10 @@ const localAuth = {
       });
     } else {
       // eslint-disable-next-line
-      this.requestToken(url.match(/\?code=([\w\/\-]+)/)[1]);
+      const accessCode = url.match(/\?code=(.+)/);
+      if (accessCode) {
+        this.requestToken(accessCode[1]);
+      }
     }
   },
 

--- a/scripts/baekjoon/baekjoon.js
+++ b/scripts/baekjoon/baekjoon.js
@@ -86,7 +86,7 @@ function parseLoader(doc = document) {
       Swal.fire({
         icon: 'error',
         title: '에러 발생',
-        html: `<b>BaekjoonHub</b> 익스텐션이 실행하였습니다<br/>에러가 발생했습니다. 개발자에게 문의해주세요.<br/><br/>${e}`,
+        html: `<b>BaekjoonHub</b> 익스텐션이 실행하였습니다<br/>에러가 발생했습니다. 개발자에게 문의해주세요.<br/><br/>${e?.stack ?? e}`,
         footer: '<a href="https://github.com/BaekjoonHub/BaekjoonHub/issues">개발자에게 문의하기</a>',
       });
     }


### PR DESCRIPTION
- Fix 에러 발생 시에 나오는 에러 모달 상세 내역에 코드 스택이 포함되도록 수정
- Fix 일반 github 사용 시에는 엑세스코드를 파싱하지 않도록 처리
- Fix 사용하지 않는 릿허브 더미코드 삭제

매니패스트 버전업은 하지 않아도 무방할 것 같습니다.