### PR TITLE
Hotfix 타익스텐션과 사용할 시에 파싱이 되지 않은 오류 수정 (#146)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,7 @@
   ],
   "host_permissions": [
     "https://www.acmicpc.net/",
-    "https://programmers.co.kr/",
+    "https://school.programmers.co.kr/",
     "https://github.com/",
     "https://swexpertacademy.com/"
   ],

--- a/scripts/baekjoon/parsing.js
+++ b/scripts/baekjoon/parsing.js
@@ -109,7 +109,7 @@ function makeDetailMessageAndReadme(data) {
 function findUsername() {
   const el = document.querySelector('a.username');
   if (isNull(el)) return null;
-  const username = el.innerText;
+  const username = el?.innerText?.trim();
   if (isEmpty(username)) return null;
   return username;
 }


### PR DESCRIPTION
타 익스텐션 사용 시에 예기치 않는 공백이 추가되어 기존 유저와 제대로 비교되지 않는 오류가 있어 수정합니다