### PR TITLE
블로그모드 입니다.

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -71,3 +71,16 @@ body {
   border: 0px solid #2f5496;
   background: #2f5496;
 }
+#blog_onoff {
+  appearance: none;
+}
+#blog_onoff:checked+#onffmain {
+  border: 0px solid #8faadc;
+  background: #8faadc;
+}
+
+#blog_onoff:checked+#onffmain #onffball {
+  left: 30px;
+  border: 0px solid #2f5496;
+  background: #2f5496;
+}

--- a/popup.html
+++ b/popup.html
@@ -41,6 +41,7 @@
         </div>
 
         <div id="commit_mode" hidden>
+          <p id="blog_mode" class="ui small header" style="margin-top: 5px; margin-bottom: 6px !important"></p>
           <p id="repo_url" class="ui small header" style="margin-top: 5px; margin-bottom: 6px !important"></p>
           <div class="ui small header" style="margin-bottom: 5px; margin-top: 0px !important">
             Want more features?
@@ -50,6 +51,11 @@
 
         <!-- 기능 on/off -->
         <div style="margin-top: 10px;">
+          <span  class="ui small header" style="margin-top: 1em;
+          margin-bottom: 6px !important;
+          vertical-align: super;
+          font-size: 1.4em;
+          display: inline-block;">Use BaekjoonHub: </span>
           <input type="checkbox" id="onffbox">
           <label for="onffbox" id="onffmain">
             <span id="onffball"></span>

--- a/popup.js
+++ b/popup.js
@@ -31,10 +31,26 @@ chrome.storage.local.get('BaekjoonHub_token', (data) => {
             if (data2 && data2.mode_type === 'commit') {
               $('#commit_mode').show();
               /* Get problem stats and repo link */
-              chrome.storage.local.get(['stats', 'BaekjoonHub_hook'], (data3) => {
+              chrome.storage.local.get(['stats', 'BaekjoonHub_hook','blog_mode'], (data3) => {
                 const BaekjoonHubHook = data3.BaekjoonHub_hook;
+                const blogMode = data3.blog_mode;
                 if (BaekjoonHubHook) {
                   $('#repo_url').html(`Your Repo: <a target="blank" style="color: cadetblue !important;" href="https://github.com/${BaekjoonHubHook}">${BaekjoonHubHook}</a>`);
+
+                  //블로그모드 추가
+                  $('#blog_mode').html(`<span style=    "vertical-align: super">Blog Mode(for JeKyll) : </span><input type="checkbox" id="blog_onoff">
+                  <label for="blog_onoff" id="onffmain">
+                    <span id="onffball"></span>
+                  </label>`)
+
+                  //블로그모드 onoff 이벤트
+                  $('#blog_onoff').on('click', () => {
+                    const blogToggle = $('#blog_onoff').is(':checked');
+                    chrome.storage.local.set({ 'blog_mode': blogToggle }, () => { });
+                    //블로그모드 on/off 마다 stats 초기화
+                    chrome.storage.local.set({'stats':{}}, ()=>{});
+                  });
+                  $('#blog_onoff').prop('checked', blogMode);
                 }
               });
             } else {

--- a/scripts/baekjoon/baekjoon.js
+++ b/scripts/baekjoon/baekjoon.js
@@ -10,6 +10,13 @@ let loader;
 const currentUrl = window.location.href;
 if (debug) console.log(currentUrl);
 
+// 사이트 식별
+const thisSite = "백준";
+// 블로그모드 식별
+let isBlogMode = false;
+(async function() {
+  isBlogMode = await getObjectFromLocalStorage('blog_mode');
+})(); 
 // 문제 제출 사이트의 경우에는 로더를 실행하고, 유저 페이지의 경우에는 버튼을 생성한다.
 // 백준 사이트 로그인 상태이면 username이 있으며, 아니면 없다.
 const username = findUsername();
@@ -72,8 +79,8 @@ async function beginUpload(bojData) {
     }
 
     /* 현재 제출하려는 소스코드가 기존 업로드한 내용과 같다면 중지 */
-    if (debug) console.log('local:', await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.fileName}`), 'calcSHA:', calculateBlobSHA(bojData.code));
-    if ((await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.fileName}`)) === calculateBlobSHA(bojData.code)) {
+    if (debug) console.log('local:', await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.codeFileName}`), 'calcSHA:', calculateBlobSHA(bojData.code));
+    if ((await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.codeFileName}`)) === calculateBlobSHA(bojData.code)) {
       markUploadedCSS();
       console.log(`현재 제출번호를 업로드한 기록이 있습니다.` /* submissionID ${bojData.submissionId}` */);
       return;

--- a/scripts/baekjoon/parsing.js
+++ b/scripts/baekjoon/parsing.js
@@ -81,10 +81,10 @@ function makeDetailMessageAndReadme(data) {
   const codeFileName = `${convertSingleCharToDoubleChar(title)}.${languages[language]}`;
   //md파일 제목 추가
   const readmeFileName = isBlogMode ? `${getyymmdd('-')}-${thisSite}.${problemId}.md` : "README.md";
-  // prettier-ignore-start
+  
   // 블로그모드에서 새로만드는 md파일도 readme라는 이름으로 사용
   const readme = makeReadme(data);
-  // prettier-ignore-end
+
   return {
     directory,
     codeFileName,

--- a/scripts/baekjoon/parsing.js
+++ b/scripts/baekjoon/parsing.js
@@ -95,6 +95,7 @@ function makeDetailMessageAndReadme(data) {
   };
 }
 
+//readme 생성함수
 function makeReadme(data) {
   const { problemId, submissionTime , title, level, tags,
     problem_description, problem_input, problem_output,
@@ -102,7 +103,6 @@ function makeReadme(data) {
   const tagl = [];
   tags.forEach((tag) => tagl.push(`${categories[tag.key]}(${tag.key})`));  
   const category = tagl.join(', ');
-  console.log(problem_description)
   if(isBlogMode){
     return `---\n`
     + `title: '[${thisSite}] ${problemId}번: ${title}(${language}/${languages[language]})' \n`

--- a/scripts/baekjoon/uploadfunctions.js
+++ b/scripts/baekjoon/uploadfunctions.js
@@ -15,7 +15,7 @@ async function uploadOneSolveProblemOnGit(bojData, cb) {
     console.error('token or hook is null', token, hook);
     return;
   }
-  return upload(token, hook, bojData.code, bojData.readme, bojData.directory, bojData.fileName, bojData.message, cb);
+  return upload(token, hook, bojData.code, bojData.codeFileName, bojData.readme, bojData.readmeFileName, bojData.directory,  bojData.message, cb);
 }
 
 /** Github api를 사용하여 업로드를 합니다.
@@ -29,7 +29,7 @@ async function uploadOneSolveProblemOnGit(bojData, cb) {
  * @param {string} commitMessage - 커밋 메시지
  * @param {function} cb - 콜백 함수 (ex. 업로드 후 로딩 아이콘 처리 등)
  */
-async function upload(token, hook, sourceText, readmeText, directory, filename, commitMessage, cb) {
+async function upload(token, hook, sourceText, codeFilename, readmeText, readmeFileName, directory,  commitMessage, cb) {
   /* 업로드 후 커밋 */
   const git = new GitHub(hook, token);
   const stats = await getStats();
@@ -39,8 +39,9 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
     stats.branches[hook] = default_branch;
   }
   const { refSHA, ref } = await git.getReference(default_branch);
-  const source = await git.createBlob(sourceText, `${directory}/${filename}`); // 소스코드 파일
-  const readme = await git.createBlob(readmeText, `${directory}/README.md`); // readme 파일
+  const source = await git.createBlob(sourceText, `${directory}/${codeFilename}`); // 소스코드 파일
+  const readme = await git.createBlob(readmeText, `${directory}/${readmeFileName}`); // readme 파일
+  console.log(readme)
   const treeSHA = await git.createTree(refSHA, [source, readme]);
   const commitSHA = await git.createCommit(commitMessage, treeSHA, refSHA);
   await git.updateHead(ref, commitSHA);
@@ -78,7 +79,7 @@ async function uploadAllSolvedProblem() {
   const datas = await findDatas(list);
   await Promise.all(
     datas.map(async (bojData) => {
-      const sha = getObjectDatafromPath(submission, `${hook}/${bojData.directory}/${bojData.fileName}`);
+      const sha = getObjectDatafromPath(submission, `${hook}/${bojData.directory}/${bojData.codeFileName}`);
       if (debug) console.log('sha', sha, 'calcSHA:', calculateBlobSHA(bojData.code));
       if (isNull(sha) || sha !== calculateBlobSHA(bojData.code)) {
         bojDatas.push(bojData);
@@ -94,8 +95,8 @@ async function uploadAllSolvedProblem() {
   setMultiLoaderDenom(bojDatas.length);
   await asyncPool(2, bojDatas, async (bojData) => {
     if (!isEmpty(bojData.code) && !isEmpty(bojData.readme)) {
-      const source = await git.createBlob(bojData.code, `${bojData.directory}/${bojData.fileName}`); // 소스코드 파일
-      const readme = await git.createBlob(bojData.readme, `${bojData.directory}/README.md`); // readme 파일
+      const source = await git.createBlob(bojData.code, `${bojData.directory}/${bojData.codeFileName}`); // 소스코드 파일
+      const readme = await git.createBlob(bojData.readme, `${bojData.directory}/${bojData.readmeFileName}`); // readme 파일
       tree_items.push(...[source, readme]);
     }
     incMultiLoader(1);

--- a/scripts/baekjoon/uploadfunctions.js
+++ b/scripts/baekjoon/uploadfunctions.js
@@ -23,13 +23,14 @@ async function uploadOneSolveProblemOnGit(bojData, cb) {
  * @param {string} token - github api 토큰
  * @param {string} hook - github api hook
  * @param {string} sourceText - 업로드할 소스코드
+ * @param {string} codeFilename - 업로드할 소스파일 이름
  * @param {string} readmeText - 업로드할 readme
+ * @param {string} readmeFilename - 업로드할 md파일 이름
  * @param {string} directory - 업로드할 파일의 경로
- * @param {string} filename - 업로드할 파일명
  * @param {string} commitMessage - 커밋 메시지
  * @param {function} cb - 콜백 함수 (ex. 업로드 후 로딩 아이콘 처리 등)
  */
-async function upload(token, hook, sourceText, codeFilename, readmeText, readmeFileName, directory,  commitMessage, cb) {
+async function upload(token, hook, sourceText, codeFilename, readmeText, readmeFileName, directory, commitMessage, cb) {
   /* 업로드 후 커밋 */
   const git = new GitHub(hook, token);
   const stats = await getStats();

--- a/scripts/baekjoon/util.js
+++ b/scripts/baekjoon/util.js
@@ -187,7 +187,8 @@ function convertImageTagAbsoluteURL(doc = document) {
   if(isNull(doc)) return;
   // img tag replace Relative URL to Absolute URL.
   Array.from(doc.getElementsByTagName('img'), (x) => {
-    x.setAttribute('src', x.currentSrc);
+    // x.currentSrc가 공백으로 나와서 x.src 추가
+    x.setAttribute('src', x.currentSrc || x.src);
     return x;
   });
 }

--- a/scripts/programmers/parsing.js
+++ b/scripts/programmers/parsing.js
@@ -44,7 +44,7 @@ async function makeData(origin) {
   const { problemId, level, language_extension, title, runtime, memory, code } = origin;
 
   const rootDir = isBlogMode ? "_posts/" : "";
-  const directory = `${rootDir}프로그래머스/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`;
+  const directory = `${rootDir}${thisSite}/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`;
   const message = `[${level.replace('lv', 'level ')}] Title: ${title}, Time: ${runtime}, Memory: ${memory} -BaekjoonHub`;
    //기존 filenName => codeFileName
    const codeFileName = `${convertSingleCharToDoubleChar(title)}.${language_extension}`;

--- a/scripts/programmers/parsing.js
+++ b/scripts/programmers/parsing.js
@@ -41,14 +41,40 @@ async function parseData() {
 }
 
 async function makeData(origin) {
-  const { problem_description, problemId, level, result_message, division, language_extension, title, runtime, memory, code } = origin;
-  const directory = `프로그래머스/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`;
+  const { problemId, level, language_extension, title, runtime, memory, code } = origin;
+
+  const rootDir = isBlogMode ? "_posts/" : "";
+  const directory = `${rootDir}프로그래머스/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`;
   const message = `[${level.replace('lv', 'level ')}] Title: ${title}, Time: ${runtime}, Memory: ${memory} -BaekjoonHub`;
-  const fileName = `${convertSingleCharToDoubleChar(title)}.${language_extension}`;
-  // prettier-ignore
-  const readme =
-    `# [${level.replace('lv', 'level ')}] ${title} - ${problemId} \n\n`
-    + `[문제 링크](${link}) \n\n`
+   //기존 filenName => codeFileName
+   const codeFileName = `${convertSingleCharToDoubleChar(title)}.${language_extension}`;
+   //md파일 제목 추가
+   const readmeFileName = isBlogMode ? `${getyymmdd('-')}-${thisSite}.${problemId}.md` : "README.md";
+  const readme = makeReadme(origin);
+    
+  return {
+    directory,
+    codeFileName,
+    message,
+    readmeFileName,
+    readme,
+    code
+  };
+}
+
+//readme 생성함수
+function makeReadme(origin) {
+  const { problemId, title, level, division, problem_description,
+    code, language_extension, memory, runtime, result_message } = origin;
+  if(isBlogMode){
+    return `---\n`
+    + `title: '[${thisSite}] ${problemId}번: ${title}(${language_extension})' \n`
+    + `date: ${getyyMMddhhmmss('-')}\n`
+    + `categories: [${thisSite},${level}] \n`
+    + `tags: [${division.split('/')}] \n`
+    + `---\n\n`
+    + `# [${level}] ${title} - ${problemId} \n\n`
+    + `[문제 링크](https://www.acmicpc.net/problem/${problemId}) \n\n`
     + `### 성능 요약\n\n`
     + `메모리: ${memory}, `
     + `시간: ${runtime}\n\n`
@@ -58,6 +84,24 @@ async function makeData(origin) {
     + `${result_message}\n\n`
     + `### 문제 설명\n\n`
     + `${problem_description}\n\n`
+    + `### 정답 코드 \n\n`
+    + '```'+`${language_extension}\n`
+    + `${code}\n`
+    + '```\n'
     + `> 출처: 프로그래머스 코딩 테스트 연습, https://programmers.co.kr/learn/challenges`;
-  return { problemId, directory, message, fileName, readme, code };
+  }
+  else{
+   return `# [${level.replace('lv', 'level ')}] ${title} - ${problemId} \n\n`
+   + `[문제 링크](${link}) \n\n`
+   + `### 성능 요약\n\n`
+   + `메모리: ${memory}, `
+   + `시간: ${runtime}\n\n`
+   + `### 구분\n\n`
+   + `${division.replace('/', ' > ')}\n\n`
+   + `### 채점결과\n\n`
+   + `${result_message}\n\n`
+   + `### 문제 설명\n\n`
+   + `${problem_description}\n\n`
+   + `> 출처: 프로그래머스 코딩 테스트 연습, https://programmers.co.kr/learn/challenges`;
+  }
 }

--- a/scripts/programmers/programmers.js
+++ b/scripts/programmers/programmers.js
@@ -1,5 +1,5 @@
 // Set to true to enable console log
-const debug = true;
+const debug = false;
 
 /* 
   문제 제출 맞음 여부를 확인하는 함수

--- a/scripts/programmers/programmers.js
+++ b/scripts/programmers/programmers.js
@@ -1,5 +1,5 @@
 // Set to true to enable console log
-const debug = false;
+const debug = true;
 
 /* 
   문제 제출 맞음 여부를 확인하는 함수
@@ -8,6 +8,15 @@ const debug = false;
 let loader;
 
 const currentUrl = window.location.href;
+
+// 사이트 식별
+const thisSite = "프로그래머스";
+// 블로그모드 식별
+let isBlogMode = false;
+(async function() {
+  isBlogMode = await getObjectFromLocalStorage('blog_mode');
+  console.log(isBlogMode)
+})(); 
 
 // 프로그래머스 연습 문제 주소임을 확인하고, 맞다면 로더를 실행
 if (currentUrl.includes('/learn/courses/30') && currentUrl.includes('lessons')) startLoader();
@@ -57,8 +66,8 @@ async function beginUpload(bojData) {
     }
 
     /* 현재 제출하려는 소스코드가 기존 업로드한 내용과 같다면 중지 */
-    if (debug) console.log('local:', await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.fileName}`), 'calcSHA:', calculateBlobSHA(bojData.code));
-    if ((await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.fileName}`)) === calculateBlobSHA(bojData.code)) {
+    if (debug) console.log('local:', await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.codeFileName}`), 'calcSHA:', calculateBlobSHA(bojData.code));
+    if ((await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.codeFileName}`)) === calculateBlobSHA(bojData.code)) {
       markUploadedCSS();
       console.log(`현재 제출번호를 업로드한 기록이 있습니다. problemIdID ${bojData.problemId}`);
       return;

--- a/scripts/programmers/uploadfunctions.js
+++ b/scripts/programmers/uploadfunctions.js
@@ -15,7 +15,7 @@ async function uploadOneSolveProblemOnGit(bojData, cb) {
     console.error('token or hook is null', token, hook);
     return;
   }
-  return upload(token, hook, bojData.code, bojData.readme, bojData.directory, bojData.fileName, bojData.message, cb);
+  return upload(token, hook, bojData.code, bojData.codeFileName, bojData.readme, bojData.readmeFileName, bojData.directory,  bojData.message, cb);
 }
 
 /** Github api를 사용하여 업로드를 합니다.
@@ -29,7 +29,7 @@ async function uploadOneSolveProblemOnGit(bojData, cb) {
  * @param {string} commitMessage - 커밋 메시지
  * @param {function} cb - 콜백 함수 (ex. 업로드 후 로딩 아이콘 처리 등)
  */
-async function upload(token, hook, sourceText, readmeText, directory, filename, commitMessage, cb) {
+ async function upload(token, hook, sourceText, codeFilename, readmeText, readmeFileName, directory,  commitMessage, cb) {
   /* 업로드 후 커밋 */
   const git = new GitHub(hook, token);
   const stats = await getStats();
@@ -39,8 +39,8 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
     stats.branches[hook] = default_branch;
   }
   const { refSHA, ref } = await git.getReference(default_branch);
-  const source = await git.createBlob(sourceText, `${directory}/${filename}`); // 소스코드 파일
-  const readme = await git.createBlob(readmeText, `${directory}/README.md`); // readme 파일
+  const source = await git.createBlob(sourceText, `${directory}/${codeFilename}`); // 소스코드 파일
+  const readme = await git.createBlob(readmeText, `${directory}/${readmeFileName}`); // readme 파일
   const treeSHA = await git.createTree(refSHA, [source, readme]);
   const commitSHA = await git.createCommit(commitMessage, treeSHA, refSHA);
   await git.updateHead(ref, commitSHA);

--- a/scripts/programmers/uploadfunctions.js
+++ b/scripts/programmers/uploadfunctions.js
@@ -23,9 +23,10 @@ async function uploadOneSolveProblemOnGit(bojData, cb) {
  * @param {string} token - github api 토큰
  * @param {string} hook - github api hook
  * @param {string} sourceText - 업로드할 소스코드
+ * @param {string} codeFilename - 업로드할 소스파일 이름
  * @param {string} readmeText - 업로드할 readme
+ * @param {string} readmeFilename - 업로드할 md파일 이름
  * @param {string} directory - 업로드할 파일의 경로
- * @param {string} filename - 업로드할 파일명
  * @param {string} commitMessage - 커밋 메시지
  * @param {function} cb - 콜백 함수 (ex. 업로드 후 로딩 아이콘 처리 등)
  */

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -227,8 +227,15 @@ async function updateLocalStorageStats() {
   const tree_items = [];
   await git.getTree().then((tree) => {
     tree.forEach((item) => {
-      if (item.type === 'blob') {
-        tree_items.push(item);
+      //블로그모드일경우 불필요한 blob이 많아서 특정위치 blob만 가져옴.
+      if(isBlogMode) {
+        if ( (/^_posts\/백준|프로그래머스|SWEA/).test(item.path) && item.type === 'blob') {
+          tree_items.push(item);
+        }
+      }else {
+        if (item.type === 'blob') {
+          tree_items.push(item);
+        }
       }
     });
   });

--- a/scripts/swexpertacademy/parsing.js
+++ b/scripts/swexpertacademy/parsing.js
@@ -80,19 +80,57 @@ async function parseData() {
 }
 
 async function makeData(origin) {
-  const { link, problemId, level, extension, title, runtime, memory, code, length } = origin;
-  const directory = `SWEA/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`;
+  const { problemId, level, extension, title, runtime, memory, code,} = origin;
+
+  const rootDir = isBlogMode ? "_posts/" : "";
+  const directory = `${rootDir}${thisSite}/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`;
   const message = `[${level}] Title: ${title}, Time: ${runtime}, Memory: ${memory} -BaekjoonHub`;
-  const fileName = `${convertSingleCharToDoubleChar(title)}.${extension}`;
-  // prettier-ignore
-  const readme =
-    `# [${level}] ${title} - ${problemId} \n\n`
+  const codeFileName = `${convertSingleCharToDoubleChar(title)}.${extension}`;
+  //md파일 제목 추가
+  const readmeFileName = isBlogMode ? `${getyymmdd('-')}-${thisSite}.${problemId}.md` : "README.md";
+  const readme = makeReadme(origin);
+    
+  return {
+    directory,
+    codeFileName,
+    message,
+    readmeFileName,
+    readme,
+    code
+  };
+}
+
+//readme 생성함수
+function makeReadme(origin) {
+  const { problemId, title, level, link, length,
+    code, extension, memory, runtime } = origin;
+  if(isBlogMode){
+    return `---\n`
+    + `title: '[${thisSite}] ${problemId}번: ${title}(${extension})' \n`
+    + `date: ${getyyMMddhhmmss('-')}\n`
+    + `categories: [${thisSite},${level}] \n`
+    + `---\n\n`
+    +`# [${level}] ${title} - ${problemId} \n\n`
     + `[문제 링크](${link}) \n\n`
     + `### 성능 요약\n\n`
     + `메모리: ${memory}, `
     + `시간: ${runtime}, `
     + `코드길이: ${length} Bytes\n\n`
     + `\n\n`
+    + `### 정답 코드 \n\n`
+    + '```'+`${extension}\n`
+    + `${code}\n`
+    + '```\n'
     + `> 출처: SW Expert Academy, https://swexpertacademy.com/main/code/problem/problemList.do`;
-  return { problemId, directory, message, fileName, readme, code };
+  }
+  else{
+   return `# [${level}] ${title} - ${problemId} \n\n`
+   + `[문제 링크](${link}) \n\n`
+   + `### 성능 요약\n\n`
+   + `메모리: ${memory}, `
+   + `시간: ${runtime}, `
+   + `코드길이: ${length} Bytes\n\n`
+   + `\n\n`
+   + `> 출처: SW Expert Academy, https://swexpertacademy.com/main/code/problem/problemList.do`;
+  }
 }

--- a/scripts/swexpertacademy/swexpertacademy.js
+++ b/scripts/swexpertacademy/swexpertacademy.js
@@ -9,6 +9,14 @@ let loader;
 
 const currentUrl = window.location.href;
 
+// 사이트 식별
+const thisSite = "SWEA";
+// 블로그모드 식별
+let isBlogMode = false;
+(async function() {
+  isBlogMode = await getObjectFromLocalStorage('blog_mode');
+})(); 
+
 // SWEA 연습 문제 주소임을 확인하고, 맞는 파서를 실행
 if (currentUrl.includes('/main/solvingProblem/solvingProblem.do') && document.querySelector('header > h1 > span').textContent === '모의 테스트') startLoader();
 else if (currentUrl.includes('/main/code/problem/problemSolver.do') && currentUrl.includes('extension=BaekjoonHub')) parseAndUpload();
@@ -68,8 +76,8 @@ async function beginUpload(bojData) {
     }
 
     /* 현재 제출하려는 소스코드가 기존 업로드한 내용과 같다면 중지 */
-    if (debug) console.log('local:', await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.fileName}`), 'calcSHA:', calculateBlobSHA(bojData.code));
-    if ((await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.fileName}`)) === calculateBlobSHA(bojData.code)) {
+    if (debug) console.log('local:', await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.codeFileName}`), 'calcSHA:', calculateBlobSHA(bojData.code));
+    if ((await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.codeFileName}`)) === calculateBlobSHA(bojData.code)) {
       markUploadedCSS();
       console.log(`현재 제출번호를 업로드한 기록이 있습니다. problemIdID ${bojData.problemId}`);
       return;

--- a/scripts/swexpertacademy/uploadfunctions.js
+++ b/scripts/swexpertacademy/uploadfunctions.js
@@ -15,7 +15,7 @@ async function uploadOneSolveProblemOnGit(bojData, cb) {
     console.error('token or hook is null', token, hook);
     return;
   }
-  return upload(token, hook, bojData.code, bojData.readme, bojData.directory, bojData.fileName, bojData.message, cb);
+  return upload(token, hook, bojData.code, bojData.codeFileName, bojData.readme, bojData.readmeFileName, bojData.directory,  bojData.message, cb);
 }
 
 /** Github api를 사용하여 업로드를 합니다.
@@ -29,7 +29,7 @@ async function uploadOneSolveProblemOnGit(bojData, cb) {
  * @param {string} commitMessage - 커밋 메시지
  * @param {function} cb - 콜백 함수 (ex. 업로드 후 로딩 아이콘 처리 등)
  */
-async function upload(token, hook, sourceText, readmeText, directory, filename, commitMessage, cb) {
+ async function upload(token, hook, sourceText, codeFilename, readmeText, readmeFileName, directory,  commitMessage, cb) {
   /* 업로드 후 커밋 */
   const git = new GitHub(hook, token);
   const stats = await getStats();
@@ -39,8 +39,8 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
     stats.branches[hook] = default_branch;
   }
   const { refSHA, ref } = await git.getReference(default_branch);
-  const source = await git.createBlob(sourceText, `${directory}/${filename}`); // 소스코드 파일
-  const readme = await git.createBlob(readmeText, `${directory}/README.md`); // readme 파일
+  const source = await git.createBlob(sourceText, `${directory}/${codeFilename}`); // 소스코드 파일
+  const readme = await git.createBlob(readmeText, `${directory}/${readmeFileName}`); // readme 파일
   const treeSHA = await git.createTree(refSHA, [source, readme]);
   const commitSHA = await git.createCommit(commitMessage, treeSHA, refSHA);
   await git.updateHead(ref, commitSHA);

--- a/scripts/swexpertacademy/uploadfunctions.js
+++ b/scripts/swexpertacademy/uploadfunctions.js
@@ -23,9 +23,10 @@ async function uploadOneSolveProblemOnGit(bojData, cb) {
  * @param {string} token - github api 토큰
  * @param {string} hook - github api hook
  * @param {string} sourceText - 업로드할 소스코드
+ * @param {string} codeFilename - 업로드할 소스파일 이름
  * @param {string} readmeText - 업로드할 readme
+ * @param {string} readmeFilename - 업로드할 md파일 이름
  * @param {string} directory - 업로드할 파일의 경로
- * @param {string} filename - 업로드할 파일명
  * @param {string} commitMessage - 커밋 메시지
  * @param {function} cb - 콜백 함수 (ex. 업로드 후 로딩 아이콘 처리 등)
  */

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -259,3 +259,26 @@ async function asyncPool(poolLimit, array, iteratorFn) {
 function combine(a, b) {
   return a.map((x, i) => Object.assign({}, x, b[i]));
 }
+
+//블로그모드
+//날짜 형식 호출
+function getyymmdd(separator) {
+  const nD= new Date();
+  const year = nD.getFullYear();
+  const month = nD.getMonth() + 1;
+  const date = nD.getDate();
+return `${year}${separator}${month >= 10 ? month : '0' + month}${separator}${date >= 10 ? date : '0' + date}`;
+}
+function parseDate(submissonTime) {
+  return submissonTime.replace("년 ","-").replace("월 ","-").replace("일 ","-");
+}
+function getyyMMddhhmmss(separator) {
+  const nD= new Date();
+  const year = nD.getFullYear();
+  const month = nD.getMonth() + 1;
+  const date = nD.getDate();
+  const hour = nD.getHours();
+  const minute = nD.getMinutes();
+  const second = nD.getSeconds();
+return `${year}${separator}${month >= 10 ? month : '0' + month}${separator}${date >= 10 ? date : '0' + date}${separator}${hour >= 10 ? hour : '0' + hour}:${minute >= 10 ? minute : '0' + minute}:${second >= 10 ? second : '0' + second}`;
+}


### PR DESCRIPTION
블로그모드시 
1. 저장 위치가 _posts/ 로 변합니다. ( _posts 하위 경로는 기존과 동일합니다. )
2. on/off시 'stats'를 초기화 합니다. ( on/off시 원격repo와 동기화를 해야 할 필요가 있다고 생각했습니다.)
3. 블로그모드에서 stats 동기화시 _posts/ 하위 경로 blob만 가져옵니다. ( 문제가 아닌 blob까지 가져와서 불필요 하다고 생각했습니다 )
4. 기존 README.md 파일이 yyyy-mm-dd-{사이트이름}{문제번호}.md 로 저장됩니다.
5. md파일 내용에 jekyll 포스트에 필요한 요소와 code가 추가됩니다.
6. 포스트 요소 중 categories 는 [ {사이트이름},{level} ] 로 구성되고 tags의 경우 백준은 문제 분류, 프로그래머스는 division 으로 저장되고 SWEA는 없습니다.
7. 백준은 포스팅 날짜가 제출했던 submissionTime 으로 저장되고 프로그래머스, SWEA는 커밋하는 시점으로 저장됩니다.

기타
1. 백준 전체업로드시 submissionTime이 undefined로 나와서 확인해보니 submissionTime이 data-original-title 대신 title에 저장되는걸 확인했습니다. data-original-title가 false 일때 title이 출력되도록 코드 추가했습니다.
2. 백준 업로드시 이미지경로가 공백으로 나와 확인해보니 convertImageTagAbsoluteURL 에서 x.currentSrc가 공백으로 찍혀 나왔습니다. x.currentSrc 가 false일때 src를 기존 x.src를 사용하도록 코드 추가했습니다.

popup
1. 블로그모드 on/off를 추가했습니다.
2. 블로그모드 on/off에 기존 버튼을 재사용해서 기존 버튼의 역할을 명시할 필요가 있다고 생각하여 기존 버튼 앞에 문구를 추가했습니다.
