### PR TITLE
FIX: Programmers parsing result_message

### DIFF
--- a/scripts/programmers/parsing.js
+++ b/scripts/programmers/parsing.js
@@ -25,11 +25,11 @@ async function parseData() {
   const problem_description = document.querySelector('div.guide-section-description > div.markdown').innerHTML;
   const language_extension = document.querySelector('div.editor > ul > li.nav-item > a').innerText.split('.')[1]
   const code = document.querySelector('textarea#code').value;
-  const result_message =
-    [...document.querySelectorAll('#output > pre.console-content > div.console-message')]
-      .map((x) => x.innerText)
-      .filter((x) => x.includes(': '))
-      .reduce((x, y) => `${x}<br/>${y}`, '') || 'Empty';
+  const result_message = 
+      [...document.querySelectorAll('#output .console-message')]
+        .map((node) => node.textContent)
+        .filter((text) => text.includes(":"))
+        .reduce((cur, next) => cur ? `${cur}<br/>${next}` : next, '') || 'Empty';
   const [runtime, memory] = [...document.querySelectorAll('td.result.passed')]
     .map((x) => x.innerText)
     .map((x) => x.replace(/[^., 0-9a-zA-Z]/g, '').trim())


### PR DESCRIPTION
프로그래머스 기준 정답과 점수가 나왔음에도 불구하고 _채점결과_가 Empty로 발생하는 문제를 해결

수정 후 압축해제된 파일을 확장 프로그램에 업로드하여 테스트해본 결과 아래와 같이 정상 작동하는것을 확인
### before
![image](https://github.com/BaekjoonHub/BaekjoonHub/assets/89904226/51c3ad50-33cd-4427-9372-2d0283476b77)


### after
![image](https://github.com/BaekjoonHub/BaekjoonHub/assets/89904226/d9ca98ce-3cee-44b6-b6af-dcca4ff86ad5)
