### PR TITLE
Feat readme 작성 시 제출 일자 기록

### DIFF
--- a/scripts/baekjoon/parsing.js
+++ b/scripts/baekjoon/parsing.js
@@ -51,7 +51,6 @@ function makeDetailMessageAndReadme(data) {
     + `-BaekjoonHub`;
   const category = problem_tags.join(', ');
   const fileName = `${convertSingleCharToDoubleChar(title)}.${languages[language]}`;
-  const nowDate = new Date(Date.now());
   // prettier-ignore-start
   const readme = `# [${level}] ${title} - ${problemId} \n\n`
     + `[문제 링크](https://www.acmicpc.net/problem/${problemId}) \n\n`

--- a/scripts/baekjoon/parsing.js
+++ b/scripts/baekjoon/parsing.js
@@ -42,7 +42,7 @@ async function findData(data) {
  */
 function makeDetailMessageAndReadme(data) {
   const { problemId, submissionId, result, title, level, problem_tags,
-    problem_description, problem_input, problem_output,
+    problem_description, problem_input, problem_output, submissionTime,
     code, language, memory, runtime } = data;
   const score = parseNumberFromString(result);
   const directory = `백준/${level.replace(/ .*/, '')}/${problemId}. ${convertSingleCharToDoubleChar(title)}`;
@@ -51,6 +51,7 @@ function makeDetailMessageAndReadme(data) {
     + `-BaekjoonHub`;
   const category = problem_tags.join(', ');
   const fileName = `${convertSingleCharToDoubleChar(title)}.${languages[language]}`;
+  const dateInfo = submissionTime ?? getDateString(new Date(Date.now()));
   // prettier-ignore-start
   const readme = `# [${level}] ${title} - ${problemId} \n\n`
     + `[문제 링크](https://www.acmicpc.net/problem/${problemId}) \n\n`
@@ -60,7 +61,7 @@ function makeDetailMessageAndReadme(data) {
     + `### 분류\n\n`
     + `${category || "Empty"}\n\n` + (!!problem_description ? ''
     + `### 제출 일자\n\n`
-    + `*${new Date(Date.now()).toLocaleString()}*\n\n`
+    + `${dateInfo}\n\n`
       + `### 문제 설명\n\n${problem_description}\n\n`
       + `### 입력 \n\n ${problem_input}\n\n`
       + `### 출력 \n\n ${problem_output}\n\n` : '');

--- a/scripts/baekjoon/parsing.js
+++ b/scripts/baekjoon/parsing.js
@@ -51,6 +51,7 @@ function makeDetailMessageAndReadme(data) {
     + `-BaekjoonHub`;
   const category = problem_tags.join(', ');
   const fileName = `${convertSingleCharToDoubleChar(title)}.${languages[language]}`;
+  const nowDate = new Date(Date.now());
   // prettier-ignore-start
   const readme = `# [${level}] ${title} - ${problemId} \n\n`
     + `[문제 링크](https://www.acmicpc.net/problem/${problemId}) \n\n`
@@ -59,6 +60,8 @@ function makeDetailMessageAndReadme(data) {
     + `시간: ${runtime} ms\n\n`
     + `### 분류\n\n`
     + `${category || "Empty"}\n\n` + (!!problem_description ? ''
+    + `### 제출 일자\n\n`
+    + `*${new Date(Date.now()).toLocaleString()}*\n\n`
       + `### 문제 설명\n\n${problem_description}\n\n`
       + `### 입력 \n\n ${problem_input}\n\n`
       + `### 출력 \n\n ${problem_output}\n\n` : '');

--- a/scripts/baekjoon/util.js
+++ b/scripts/baekjoon/util.js
@@ -159,3 +159,13 @@ function convertImageTagAbsoluteURL(doc = document) {
     return x;
   });
 }
+
+/**
+ * 백준의 날짜 형식과 같게 포맷된 스트링을 반환하는 함수
+ * @example 2023년 9월 23일 16:26:26
+ * @param {Date} date
+ * @return {string} 포맷된 스트링
+ */
+function getDateString(date){
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDay()}일 ${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`
+}

--- a/scripts/enable.js
+++ b/scripts/enable.js
@@ -3,15 +3,9 @@
     가독성을 위해 따로 파일 분리함
 */
 async function checkEnable() {
-  try{
-    const enable = await getObjectFromLocalStorage('bjhEnable');
-    if (!enable) writeEnableMsgOnLog();
-    return enable;
-  }
-  catch{
-    writeEnableMsgOnLog();
-    return false;
-  }
+  const enable = await getObjectFromLocalStorage('bjhEnable');
+  if (!enable) writeEnableMsgOnLog();
+  return enable;
 }
 
 function writeEnableMsgOnLog() {

--- a/scripts/enable.js
+++ b/scripts/enable.js
@@ -3,9 +3,15 @@
     가독성을 위해 따로 파일 분리함
 */
 async function checkEnable() {
-  const enable = await getObjectFromLocalStorage('bjhEnable');
-  if (!enable) writeEnableMsgOnLog();
-  return enable;
+  try{
+    const enable = await getObjectFromLocalStorage('bjhEnable');
+    if (!enable) writeEnableMsgOnLog();
+    return enable;
+  }
+  catch{
+    writeEnableMsgOnLog();
+    return false;
+  }
 }
 
 function writeEnableMsgOnLog() {

--- a/scripts/programmers/parsing.js
+++ b/scripts/programmers/parsing.js
@@ -43,9 +43,10 @@ async function parseData() {
 async function makeData(origin) {
   const { problem_description, problemId, level, result_message, division, language_extension, title, runtime, memory, code } = origin;
   const directory = `프로그래머스/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`;
-  const levelWithLv = str(level).includes('lv') ? level : `lv${level}`.replace('lv', 'level ');
+  const levelWithLv = `${level}`.includes('lv') ? level : `lv${level}`.replace('lv', 'level ');
   const message = `[${levelWithLv}] Title: ${title}, Time: ${runtime}, Memory: ${memory} -BaekjoonHub`;
   const fileName = `${convertSingleCharToDoubleChar(title)}.${language_extension}`;
+  const dateInfo = getDateString(new Date(Date.now()));
   // prettier-ignore
   const readme =
     `# [${levelWithLv}] ${title} - ${problemId} \n\n`
@@ -57,6 +58,8 @@ async function makeData(origin) {
     + `${division.replace('/', ' > ')}\n\n`
     + `### 채점결과\n\n`
     + `${result_message}\n\n`
+    + `### 제출 일자\n\n`
+    + `${dateInfo}\n\n`
     + `### 문제 설명\n\n`
     + `${problem_description}\n\n`
     + `> 출처: 프로그래머스 코딩 테스트 연습, https://school.programmers.co.kr/learn/challenges`;

--- a/scripts/programmers/util.js
+++ b/scripts/programmers/util.js
@@ -47,3 +47,13 @@ function startUploadCountDown() {
     }
   }, 10000);
 }
+
+/**
+ * 백준의 날짜 형식과 같게 포맷된 스트링을 반환하는 함수
+ * @example 2023년 9월 23일 16:26:26
+ * @param {Date} date
+ * @return {string} 포맷된 스트링
+ */
+function getDateString(date){
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDay()}일 ${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`
+}

--- a/scripts/swexpertacademy/parsing.js
+++ b/scripts/swexpertacademy/parsing.js
@@ -62,6 +62,8 @@ async function parseData() {
   // 확장자명
   const extension = languages[language.toLowerCase()];
 
+  // 제출날짜
+  const submissionTime = document.querySelector('.smt_txt > dd').textContent.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}/g)[0];
   // 로컬스토리지에서 기존 코드에 대한 정보를 불러올 수 없다면 코드 디테일 창으로 이동 후 제출하도록 이동
   const data = await getProblemData(problemId);
   log('data', data);
@@ -76,14 +78,15 @@ async function parseData() {
   const code = data.code;
   log('파싱 완료');
   // eslint-disable-next-line consistent-return
-  return makeData({ link, problemId, level, title, extension, code, runtime, memory, length });
+  return makeData({ link, problemId, level, title, extension, code, runtime, memory, length,submissionTime });
 }
 
 async function makeData(origin) {
-  const { link, problemId, level, extension, title, runtime, memory, code, length } = origin;
+  const { link, problemId, level, extension, title, runtime, memory, code, length,submissionTime } = origin;
   const directory = `SWEA/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`;
   const message = `[${level}] Title: ${title}, Time: ${runtime}, Memory: ${memory} -BaekjoonHub`;
   const fileName = `${convertSingleCharToDoubleChar(title)}.${extension}`;
+  const dateInfo = submissionTime ?? getDateString(new Date(Date.now()));
   // prettier-ignore
   const readme =
     `# [${level}] ${title} - ${problemId} \n\n`
@@ -92,6 +95,8 @@ async function makeData(origin) {
     + `메모리: ${memory}, `
     + `시간: ${runtime}, `
     + `코드길이: ${length} Bytes\n\n`
+    + `### 제출 일자\n\n`
+    + `${dateInfo}\n\n`
     + `\n\n`
     + `> 출처: SW Expert Academy, https://swexpertacademy.com/main/code/problem/problemList.do`;
   return { problemId, directory, message, fileName, readme, code };

--- a/scripts/swexpertacademy/util.js
+++ b/scripts/swexpertacademy/util.js
@@ -70,3 +70,13 @@ function startUploadCountDown() {
 function getNickname() {
   return document.querySelector('#Beginner')?.innerText || document.querySelector('header > div > span.name')?.innerText || '';
 }
+
+/**
+ * 백준의 날짜 형식과 같게 포맷된 스트링을 반환하는 함수
+ * @example 2023년 9월 23일 16:26:26
+ * @param {Date} date
+ * @return {string} 포맷된 스트링
+ */
+function getDateString(date){
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDay()}일 ${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`
+}


### PR DESCRIPTION
## 설명
### 변경사항
- 문제 정답 후 README 생성 시 내용으로 제출 일자를 추가합니다.
- 백준과 sw expert academy의 경우 파싱된 제출 날짜를 이용, 프로그래머스는 시스템 날짜를 이용합니다.

### 관련 이슈
- #141 을 일부 반영한 PR입니다.

## 스크린샷
### Before
<img width="598" alt="image" src="https://github.com/BaekjoonHub/BaekjoonHub/assets/42014299/6db27361-6b89-40f0-89b9-2aebc4b8ef65">

### After
<img width="723" alt="image" src="https://github.com/BaekjoonHub/BaekjoonHub/assets/42014299/5007ac4f-0922-42e0-bd6d-162332cb6142">

백준

<img width="849" alt="image" src="https://github.com/BaekjoonHub/BaekjoonHub/assets/42014299/e6ba69ff-139d-4614-8297-6767629e1787">

프로그래머스

<img width="770" alt="image" src="https://github.com/BaekjoonHub/BaekjoonHub/assets/42014299/be19f115-2d96-47b6-8cf8-e8a6040b35f0">

sw expert academy
