### PR TITLE
Fix: 제출 목록 비교가 정상적으로 이뤄지지 않는 문제 해결

### DIFF
--- a/scripts/baekjoon/util.js
+++ b/scripts/baekjoon/util.js
@@ -90,7 +90,7 @@ function hasNotSubtask(a, b) {
   a = parseNumberFromString(a);
   b = parseNumberFromString(b);
 
-  if (a === NaN && b === NaN) return true;
+  if (isNaN(a) && isNaN(b)) return true;
 
   return false;
 }
@@ -106,8 +106,8 @@ function compareResult(a, b) {
   b = parseNumberFromString(b);
 
   if (typeof a === 'number' && typeof b === 'number') return -(a - b);
-  if (b === NaN) return -1;
-  if (a === NaN) return 1;
+  if (isNaN(b)) return -1;
+  if (isNaN(a)) return 1;
 }
 
 /**


### PR DESCRIPTION
- scripts/baekjoon/util.js의 selectBestSubmissionList 함수에서 실행시간이 더 빠른 submission을 반환하지 못하였으며, compareSubmissio 함수를 확인해보았습니다
- 디버깅 시, 서브테스크가 없는 문제도 hasNotSubtask 함수에서 false를 반환하는 것을 확인하였습니다.
- hasNotSubtask 함수 및 compareResult 함수의 NaN과의 비교 연산이 잘못되어 있었고, 올바른 방법인 isNaN을 활용하는 방법으로 수정하였습니다. (isNaN(NaN)은 true이며 NaN === NaN은 false입니다.)

### 기존
![image](https://github.com/BaekjoonHub/BaekjoonHub/assets/30895117/41902f98-84b6-4cd8-85e3-0536477e6de1)
![image](https://github.com/BaekjoonHub/BaekjoonHub/assets/30895117/d4a3b628-4cf9-4a2e-a2ad-535f1ead60cc)

### 수정
![image](https://github.com/BaekjoonHub/BaekjoonHub/assets/30895117/ac1a58b3-3108-42a4-a7a6-6e49cbc4eabc)

