### PR TITLE
Feat: 업로드 완료 아이콘에 업로드된 깃허브 링크 연결

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "백준허브(BaekjoonHub)",
   "description": "Automatically integrate your BOJ submissions to GitHub",
   "homepage_url": "https://github.com/BaekjoonHub/BaekjoonHub",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "author": "flaxinger",
   "action": {
     "default_icon": "assets/thumbnail.png",

--- a/scripts/baekjoon/baekjoon.js
+++ b/scripts/baekjoon/baekjoon.js
@@ -73,7 +73,7 @@ async function beginUpload(bojData) {
     log('cachedSHA', cachedSHA, 'calcSHA', calcSHA)
 
     if (cachedSHA == calcSHA) {
-      markUploadedCSS();
+      markUploadedCSS(stats.branches, bojData.directory);
       console.log(`현재 제출번호를 업로드한 기록이 있습니다.` /* submissionID ${bojData.submissionId}` */);
       return;
     }

--- a/scripts/baekjoon/uploadfunctions.js
+++ b/scripts/baekjoon/uploadfunctions.js
@@ -50,7 +50,7 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
   updateObjectDatafromPath(stats.submission, `${hook}/${readme.path}`, readme.sha);
   await saveStats(stats);
   // 콜백 함수 실행
-  if (typeof cb === 'function' && cb instanceof markUploadedCSS) {
+  if (typeof cb === 'function' && cb === markUploadedCSS) {
     cb(stats.branches, directory);
   }
 }

--- a/scripts/baekjoon/uploadfunctions.js
+++ b/scripts/baekjoon/uploadfunctions.js
@@ -50,7 +50,7 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
   updateObjectDatafromPath(stats.submission, `${hook}/${readme.path}`, readme.sha);
   await saveStats(stats);
   // 콜백 함수 실행
-  if (typeof cb === 'function' && cb === markUploadedCSS) {
+  if (typeof cb === 'function') {
     cb(stats.branches, directory);
   }
 }

--- a/scripts/baekjoon/uploadfunctions.js
+++ b/scripts/baekjoon/uploadfunctions.js
@@ -50,5 +50,7 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
   updateObjectDatafromPath(stats.submission, `${hook}/${readme.path}`, readme.sha);
   await saveStats(stats);
   // 콜백 함수 실행
-  if (typeof cb === 'function') cb();
+  if (typeof cb === 'function' && cb instanceof markUploadedCSS) {
+    cb(stats.branches, directory);
+  }
 }

--- a/scripts/baekjoon/util.js
+++ b/scripts/baekjoon/util.js
@@ -19,16 +19,23 @@ function startUpload() {
 }
 
 /**
- * 업로드 완료 아이콘 표시
+ * 업로드 완료 아이콘 표시 및 링크 생성
+ * @param {object} branches - 브랜치 정보 ('userName/repositoryName': 'branchName')
+ * @param {string} directory - 디렉토리 정보 ('백준/Gold/1. 문제이름')
+ * 1. 업로드 완료 아이콘을 표시합니다.
+ * 2. 아이콘 클릭 시 업로드된 GitHub 링크로 이동하는 이벤트 리스너를 등록합니다.
  */
-function markUploadedCSS() {
+function markUploadedCSS(branches, directory) {
   uploadState.uploading = false;
   const elem = document.getElementById('BaekjoonHub_progress_elem');
   elem.className = 'markuploaded';
-  // 1초후 창 닫기
-  // setTimeout(() => {
-  //   window.close();
-  // }, 1000);
+  uploadedUrl = "https://github.com/" +
+              Object.keys(branches)[0] + "/blob/" + 
+              branches[Object.keys(branches)[0]] + "/" + directory;
+  elem.addEventListener("click", function() {
+    window.location.href = uploadedUrl;
+  });
+  elem.style.cursor = "pointer";
 }
 
 /**

--- a/scripts/baekjoon/util.js
+++ b/scripts/baekjoon/util.js
@@ -90,7 +90,7 @@ function hasNotSubtask(a, b) {
   a = parseNumberFromString(a);
   b = parseNumberFromString(b);
 
-  if (a === NaN && b === NaN) return true;
+  if (isNaN(a) && isNaN(b)) return true;
 
   return false;
 }
@@ -106,8 +106,8 @@ function compareResult(a, b) {
   b = parseNumberFromString(b);
 
   if (typeof a === 'number' && typeof b === 'number') return -(a - b);
-  if (b === NaN) return -1;
-  if (a === NaN) return 1;
+  if (isNaN(b)) return -1;
+  if (isNaN(a)) return 1;
 }
 
 /**

--- a/scripts/baekjoon/util.js
+++ b/scripts/baekjoon/util.js
@@ -30,7 +30,7 @@ function markUploadedCSS(branches, directory) {
   const elem = document.getElementById('BaekjoonHub_progress_elem');
   elem.className = 'markuploaded';
   uploadedUrl = "https://github.com/" +
-              Object.keys(branches)[0] + "/blob/" + 
+              Object.keys(branches)[0] + "/tree/" + 
               branches[Object.keys(branches)[0]] + "/" + directory;
   elem.addEventListener("click", function() {
     window.location.href = uploadedUrl;

--- a/scripts/baekjoon/util.js
+++ b/scripts/baekjoon/util.js
@@ -29,7 +29,7 @@ function markUploadedCSS(branches, directory) {
   uploadState.uploading = false;
   const elem = document.getElementById('BaekjoonHub_progress_elem');
   elem.className = 'markuploaded';
-  uploadedUrl = "https://github.com/" +
+  const uploadedUrl = "https://github.com/" +
               Object.keys(branches)[0] + "/tree/" + 
               branches[Object.keys(branches)[0]] + "/" + directory;
   elem.addEventListener("click", function() {

--- a/scripts/programmers/programmers.js
+++ b/scripts/programmers/programmers.js
@@ -61,7 +61,7 @@ async function beginUpload(bojData) {
     calcSHA = calculateBlobSHA(bojData.code)
     log('cachedSHA', cachedSHA, 'calcSHA', calcSHA)
     if (cachedSHA == calcSHA) {
-      markUploadedCSS();
+      markUploadedCSS(stats.branches, bojData.directory);
       console.log(`현재 제출번호를 업로드한 기록이 있습니다. problemIdID ${bojData.problemId}`);
       return;
     }

--- a/scripts/programmers/uploadfunctions.js
+++ b/scripts/programmers/uploadfunctions.js
@@ -50,7 +50,7 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
   updateObjectDatafromPath(stats.submission, `${hook}/${readme.path}`, readme.sha);
   await saveStats(stats);
   // 콜백 함수 실행
-  if (typeof cb === 'function' && cb instanceof markUploadedCSS) {
+  if (typeof cb === 'function' && cb === markUploadedCSS) {
     cb(stats.branches, directory);
   }
 }

--- a/scripts/programmers/uploadfunctions.js
+++ b/scripts/programmers/uploadfunctions.js
@@ -50,7 +50,7 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
   updateObjectDatafromPath(stats.submission, `${hook}/${readme.path}`, readme.sha);
   await saveStats(stats);
   // 콜백 함수 실행
-  if (typeof cb === 'function' && cb === markUploadedCSS) {
+  if (typeof cb === 'function') {
     cb(stats.branches, directory);
   }
 }

--- a/scripts/programmers/uploadfunctions.js
+++ b/scripts/programmers/uploadfunctions.js
@@ -50,5 +50,7 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
   updateObjectDatafromPath(stats.submission, `${hook}/${readme.path}`, readme.sha);
   await saveStats(stats);
   // 콜백 함수 실행
-  if (typeof cb === 'function') cb();
+  if (typeof cb === 'function' && cb instanceof markUploadedCSS) {
+    cb(stats.branches, directory);
+  }
 }

--- a/scripts/programmers/util.js
+++ b/scripts/programmers/util.js
@@ -19,12 +19,23 @@ function startUpload() {
 }
 
 /**
- * 업로드 완료 아이콘 표시
+ * 업로드 완료 아이콘 표시 및 링크 생성
+ * @param {object} branches - 브랜치 정보 ('userName/repositoryName': 'branchName')
+ * @param {string} directory - 디렉토리 정보 ('백준/Gold/1. 문제이름')
+ * 1. 업로드 완료 아이콘을 표시합니다.
+ * 2. 아이콘 클릭 시 업로드된 GitHub 링크로 이동하는 이벤트 리스너를 등록합니다.
  */
-function markUploadedCSS() {
+function markUploadedCSS(branches, directory) {
   uploadState.uploading = false;
   const elem = document.getElementById('BaekjoonHub_progress_elem');
   elem.className = 'markuploaded';
+  uploadedUrl = "https://github.com/" +
+              Object.keys(branches)[0] + "/blob/" + 
+              branches[Object.keys(branches)[0]] + "/" + directory;
+  elem.addEventListener("click", function() {
+    window.location.href = uploadedUrl;
+  });
+  elem.style.cursor = "pointer";
 }
 
 /**

--- a/scripts/programmers/util.js
+++ b/scripts/programmers/util.js
@@ -30,7 +30,7 @@ function markUploadedCSS(branches, directory) {
   const elem = document.getElementById('BaekjoonHub_progress_elem');
   elem.className = 'markuploaded';
   uploadedUrl = "https://github.com/" +
-              Object.keys(branches)[0] + "/blob/" + 
+              Object.keys(branches)[0] + "/tree/" + 
               branches[Object.keys(branches)[0]] + "/" + directory;
   elem.addEventListener("click", function() {
     window.location.href = uploadedUrl;

--- a/scripts/programmers/util.js
+++ b/scripts/programmers/util.js
@@ -29,7 +29,7 @@ function markUploadedCSS(branches, directory) {
   uploadState.uploading = false;
   const elem = document.getElementById('BaekjoonHub_progress_elem');
   elem.className = 'markuploaded';
-  uploadedUrl = "https://github.com/" +
+  const uploadedUrl = "https://github.com/" +
               Object.keys(branches)[0] + "/tree/" + 
               branches[Object.keys(branches)[0]] + "/" + directory;
   elem.addEventListener("click", function() {

--- a/scripts/swexpertacademy/swexpertacademy.js
+++ b/scripts/swexpertacademy/swexpertacademy.js
@@ -72,7 +72,7 @@ async function beginUpload(bojData) {
     calcSHA = calculateBlobSHA(bojData.code)
     log('cachedSHA', cachedSHA, 'calcSHA', calcSHA)
     if (cachedSHA == calcSHA) {
-      markUploadedCSS();
+      markUploadedCSS(stats.branches, bojData.directory);
       console.log(`현재 제출번호를 업로드한 기록이 있습니다. problemIdID ${bojData.problemId}`);
       return;
     }

--- a/scripts/swexpertacademy/uploadfunctions.js
+++ b/scripts/swexpertacademy/uploadfunctions.js
@@ -50,7 +50,7 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
   updateObjectDatafromPath(stats.submission, `${hook}/${readme.path}`, readme.sha);
   await saveStats(stats);
   // 콜백 함수 실행
-  if (typeof cb === 'function' && cb instanceof markUploadedCSS) {
+  if (typeof cb === 'function' && cb === markUploadedCSS) {
     cb(stats.branches, directory);
   }
 }

--- a/scripts/swexpertacademy/uploadfunctions.js
+++ b/scripts/swexpertacademy/uploadfunctions.js
@@ -50,7 +50,7 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
   updateObjectDatafromPath(stats.submission, `${hook}/${readme.path}`, readme.sha);
   await saveStats(stats);
   // 콜백 함수 실행
-  if (typeof cb === 'function' && cb === markUploadedCSS) {
+  if (typeof cb === 'function') {
     cb(stats.branches, directory);
   }
 }

--- a/scripts/swexpertacademy/uploadfunctions.js
+++ b/scripts/swexpertacademy/uploadfunctions.js
@@ -50,5 +50,7 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
   updateObjectDatafromPath(stats.submission, `${hook}/${readme.path}`, readme.sha);
   await saveStats(stats);
   // 콜백 함수 실행
-  if (typeof cb === 'function') cb();
+  if (typeof cb === 'function' && cb instanceof markUploadedCSS) {
+    cb(stats.branches, directory);
+  }
 }

--- a/scripts/swexpertacademy/util.js
+++ b/scripts/swexpertacademy/util.js
@@ -34,12 +34,23 @@ function makeSubmitButton(link) {
 }
 
 /**
- * 업로드 완료 아이콘 표시
+ * 업로드 완료 아이콘 표시 및 링크 생성
+ * @param {object} branches - 브랜치 정보 ('userName/repositoryName': 'branchName')
+ * @param {string} directory - 디렉토리 정보 ('백준/Gold/1. 문제이름')
+ * 1. 업로드 완료 아이콘을 표시합니다.
+ * 2. 아이콘 클릭 시 업로드된 GitHub 링크로 이동하는 이벤트 리스너를 등록합니다.
  */
-function markUploadedCSS() {
+function markUploadedCSS(branches, directory) {
   uploadState.uploading = false;
   const elem = document.getElementById('BaekjoonHub_progress_elem');
   elem.className = 'markuploaded';
+  uploadedUrl = "https://github.com/" +
+              Object.keys(branches)[0] + "/blob/" + 
+              branches[Object.keys(branches)[0]] + "/" + directory;
+  elem.addEventListener("click", function() {
+    window.location.href = uploadedUrl;
+  });
+  elem.style.cursor = "pointer";
 }
 
 /**

--- a/scripts/swexpertacademy/util.js
+++ b/scripts/swexpertacademy/util.js
@@ -44,7 +44,7 @@ function markUploadedCSS(branches, directory) {
   uploadState.uploading = false;
   const elem = document.getElementById('BaekjoonHub_progress_elem');
   elem.className = 'markuploaded';
-  uploadedUrl = "https://github.com/" +
+  const uploadedUrl = "https://github.com/" +
               Object.keys(branches)[0] + "/tree/" + 
               branches[Object.keys(branches)[0]] + "/" + directory;
   elem.addEventListener("click", function() {

--- a/scripts/swexpertacademy/util.js
+++ b/scripts/swexpertacademy/util.js
@@ -45,7 +45,7 @@ function markUploadedCSS(branches, directory) {
   const elem = document.getElementById('BaekjoonHub_progress_elem');
   elem.className = 'markuploaded';
   uploadedUrl = "https://github.com/" +
-              Object.keys(branches)[0] + "/blob/" + 
+              Object.keys(branches)[0] + "/tree/" + 
               branches[Object.keys(branches)[0]] + "/" + directory;
   elem.addEventListener("click", function() {
     window.location.href = uploadedUrl;


### PR DESCRIPTION
## 개요

- 업로드 완료 아이콘 클릭 시 해당 문제가 업로드된 깃허브 링크로 이동할 수 있도록 합니다.
- 업로드 완료 아이콘 표시(markUploadedCSS 함수 실행)와 함께, 해당 아이콘 클릭 시 업로드된 문제의 깃허브 링크로 이동하는 이벤트 리스너를 등록합니다.

<br>

## 기대 효과

- 더 이상 업로드 후 직접 깃허브에 들어가 업로드된 내용을 확인할 필요가 없습니다. (혹은 쉽게 확인해볼 수 있습니다.)
- 백준허브가 업로드하는 README.md 형식으로 블로그에 문제를 포스팅하고 싶은 사용자들에게, 해당 링크에 접근하는 더 빠른 방법을 제공합니다.

<br>

## 스크린샷

![image](https://github.com/BaekjoonHub/BaekjoonHub/assets/30895117/5621933d-0f60-42ca-8940-8d40de26ad20)

![image](https://github.com/BaekjoonHub/BaekjoonHub/assets/30895117/f6810a44-7698-450f-b493-834ffb776f1b)
