### PR TITLE
feat: HTML 기반 프로그래머스 레벨 파싱

### DIFF
--- a/scripts/programmers/parsing.js
+++ b/scripts/programmers/parsing.js
@@ -14,7 +14,7 @@
 async function parseData() {
   const link = document.querySelector('head > meta[name$=url]').content.replace(/\?.*/g, '').trim();
   const problemId = document.querySelector('div.main > div.lesson-content').getAttribute('data-lesson-id');
-  const level = levels[problemId] !== undefined ? 'Lv.' + levels[problemId] : 'unrated';
+  const level = document.querySelector('body > div.main > div.lesson-content').getAttribute("data-challenge-level")
   const division = [...document.querySelector('ol.breadcrumb').childNodes]
     .filter((x) => x.className !== 'active')
     .map((x) => x.innerText)


### PR DESCRIPTION
## 👻 작업 요약

프로그래머스에서 레벨을 파싱할 때 특정 파일의 리터럴에 의존하던 로직을 HTML 기반으로 변경하였습니다.

* 의존 파일: https://github.com/BaekjoonHub/BaekjoonHub/blob/d1b943112addf4c6c1265065a0a59ee3048b2217/scripts/programmers/variables.js

## ⚒️ 작업 내용

* 코딩테스트 연습 페이지의 `body > div.main > div.lesson-content` 태그의 `data-challenge-level` 속성로 레벨 파싱

## 🎸 기타

이번 변경 사항으로 로컬 환경에서 테스트한 커밋 내역은 아래에서 확인하실 수 있습니다. 해당 연습 문제는 최신 릴리스 버전에서 unrated로 처리되는 문제입니다.

* 테스트 커밋: https://github.com/whatasame/BaekjoonHub/commit/63bf80dec75462fd2abd899cd3f916ec53ceea65

closes #107 

