### PR TITLE
fix: 프로그래머스 문제 타이틀 HTML 구조 변화 대응

### DIFF
--- a/scripts/programmers/parsing.js
+++ b/scripts/programmers/parsing.js
@@ -21,7 +21,7 @@ async function parseData() {
     // .filter((x) => !x.includes('코딩테스트'))
     .map((x) => convertSingleCharToDoubleChar(x))
     .reduce((a, b) => `${a}/${b}`);
-  const title = document.querySelector('#tab > li.algorithm-title').textContent.replace(/\\n/g, '').trim();
+  const title = document.querySelector('#tab > div > div.algorithm-title').textContent.replace(/\\n/g, '').trim();
   const problem_description = document.querySelector('div.guide-section-description > div.markdown').innerHTML;
   const language_extension = document.querySelector('div.editor > ul > li.nav-item > a').innerText.split('.')[1];
   const code = document.querySelector('textarea#code').value;

--- a/scripts/programmers/parsing.js
+++ b/scripts/programmers/parsing.js
@@ -21,7 +21,7 @@ async function parseData() {
     // .filter((x) => !x.includes('코딩테스트'))
     .map((x) => convertSingleCharToDoubleChar(x))
     .reduce((a, b) => `${a}/${b}`);
-  const title = document.querySelector('#tab > div > div.algorithm-title').textContent.replace(/\\n/g, '').trim();
+  const title = document.querySelector('.algorithm-title .challenge-title').textContent.replace(/\\n/g, '').trim();
   const problem_description = document.querySelector('div.guide-section-description > div.markdown').innerHTML;
   const language_extension = document.querySelector('div.editor > ul > li.nav-item > a').innerText.split('.')[1];
   const code = document.querySelector('textarea#code').value;


### PR DESCRIPTION
## 작업 요약

프로그래머스 문제 페이지에 약간의 구조 변화가 있었던 모양입니다.

해당 이슈로 인해 확장 프로그램이 작동하지 않는 걸 발견하여 수정했습니다.

## 작업 내용

- title 파싱 쿼리셀렉터를 `'#tab > li.algorithm-title'` 에서 `'#tab > div > div.algorithm-title'` 으로 변경



related issue: #226 