### PR TITLE
feat : 언어별 폴더 분기 처리 개발

### DIFF
--- a/scripts/programmers/parsing.js
+++ b/scripts/programmers/parsing.js
@@ -37,12 +37,15 @@ async function parseData() {
     .reduce((x, y) => (Number(x[0]) > Number(y[0]) ? x : y), ['0.00ms', '0.0MB'])
     .map((x) => x.replace(/(?<=[0-9])(?=[A-Za-z])/, ' '));
 
-  return makeData({ link, problemId, level, title, problem_description, division, language_extension, code, result_message, runtime, memory });
+  /*프로그래밍 언어별 폴더 정리 옵션을 위한 언어 값 가져오기*/
+  const language = document.querySelector('div#tour7 > button').textContent.trim();
+
+  return makeData({ link, problemId, level, title, problem_description, division, language_extension, code, result_message, runtime, memory, language });
 }
 
 async function makeData(origin) {
-  const { problem_description, problemId, level, result_message, division, language_extension, title, runtime, memory, code } = origin;
-  const directory = `프로그래머스/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`;
+  const { problem_description, problemId, level, result_message, division, language_extension, title, runtime, memory, code, language } = origin;
+  const directory = await getDirNameByDisOption(`프로그래머스/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`, language);
   const levelWithLv = `${level}`.includes('lv') ? level : `lv${level}`.replace('lv', 'level ');
   const message = `[${levelWithLv}] Title: ${title}, Time: ${runtime}, Memory: ${memory} -BaekjoonHub`;
   const fileName = `${convertSingleCharToDoubleChar(title)}.${language_extension}`;

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -152,6 +152,11 @@ async function getHook() {
   return await getObjectFromLocalStorage('BaekjoonHub_hook');
 }
 
+/** welcome.html 의 분기 처리 dis_option에서 설정된 boolean 값을 반환합니다. */
+async function getDisOption() {
+  return await getObjectFromLocalStorage('BaekjoonHub_disOption');
+}
+
 async function getModeType() {
   return await getObjectFromLocalStorage('mode_type');
 }
@@ -242,6 +247,19 @@ async function updateLocalStorageStats() {
   log('update stats', stats);
   return stats;
 }
+
+/**
+ * 해당 메서드는 프로그래밍 언어별 정리 옵션을 사용할 경우 언어별로 분류 하기 위함입니다.
+ * 스토리지에 저장된 {@link getDisOption}값에 따라 분기 처리됩니다.
+ *
+ * @param {string} dirName - 기존에 사용되던 분류 방식의 디렉토리 이름입니다.
+ * @param {string} language - 'BaekjoonHub_disOption'이 True일 경우에 분리에 사용될 언어 입니다.
+ * */
+async function getDirNameByDisOption(dirName, language) {
+  if (await getDisOption() === true) dirName = `${language}/${dirName}`;
+  return dirName;
+}
+
 
 /**
  * @deprecated

--- a/scripts/swexpertacademy/parsing.js
+++ b/scripts/swexpertacademy/parsing.js
@@ -78,12 +78,18 @@ async function parseData() {
   const code = data.code;
   log('파싱 완료');
   // eslint-disable-next-line consistent-return
-  return makeData({ link, problemId, level, title, extension, code, runtime, memory, length,submissionTime });
+  return makeData({ link, problemId, level, title, extension, code, runtime, memory, length, submissionTime, language});
 }
 
 async function makeData(origin) {
-  const { link, problemId, level, extension, title, runtime, memory, code, length,submissionTime } = origin;
-  const directory = `SWEA/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`;
+  const { link, problemId, level, extension, title, runtime, memory, code, length, submissionTime, language } = origin;
+  /*
+  * SWEA의 경우에는 JAVA 같이 모두 대문자인 경우가 존재합니다. 하지만 타 플랫폼들(백준, 프로그래머스)는 첫문자가 모두 대문자로 시작합니다.
+  * 그래서 이와 같은 케이스를 처리를 위해 첫문자만 대문자를 유지하고 나머지 문자는 소문자로 변환합니다.
+  * C++ 같은 경우에는 문자가 그대로 유지됩니다.
+  * */
+  const lang = (language === language.toUpperCase()) ? language.substring(0, 1) + language.substring(1).toLowerCase() : language
+  const directory = await getDirNameByDisOption(`SWEA/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`, lang);
   const message = `[${level}] Title: ${title}, Time: ${runtime}, Memory: ${memory} -BaekjoonHub`;
   const fileName = `${convertSingleCharToDoubleChar(title)}.${extension}`;
   const dateInfo = submissionTime ?? getDateString(new Date(Date.now()));

--- a/welcome.html
+++ b/welcome.html
@@ -34,8 +34,18 @@
                 <option value="link">Link an Existing Repository</option>
               </select>
             </div>
+
+            <!-- 프로그래밍 언어별 폴더 정리 옵션 -->
+            <div class="field">
+              <select id="dis_option">
+                <option value=false>Not Organized by language</option>
+                <option value=true>Organized by language</option>
+              </select>
+            </div>
           </div>
         </div>
+
+
         <div class="six wide column">
           <div class="ui form">
             <div class="field">

--- a/welcome.js
+++ b/welcome.js
@@ -195,6 +195,11 @@ const unlinkRepo = () => {
     console.log('Defaulted repo hook to NONE');
   });
 
+  /*프로그래밍 언어별 폴더 정리 옵션 세션 저장 초기화*/
+  chrome.storage.local.set({ BaekjoonHub_disOption: false}, () => {
+    console.log('DisOption Reset');
+  })
+
   /* Hide accordingly */
   document.getElementById('hook_mode').style.display = 'inherit';
   document.getElementById('commit_mode').style.display = 'none';
@@ -256,6 +261,13 @@ $('#hook_button').on('click', () => {
       }
     });
   }
+
+  /*프로그래밍 언어별 폴더 정리 옵션 세션 저장*/
+  let disOption = $('#dis_option').val();
+  const booleanParse = Boolean((disOption === 'true' || disOption === 'True'));
+  chrome.storage.local.set({ BaekjoonHub_disOption: booleanParse}, () => {
+    console.log(`dis Option is ${booleanParse}`);
+  })
 });
 
 $('#unlink a').on('click', () => {


### PR DESCRIPTION
# 작업 요약
기본옵션이 플랫폼별로 구분되고 따로 언어별로 구분되는 옵션은 없어서 추가했습니다.

# 작업 내용
- 언어별 네이밍 규칙 첫글자 대문자 나머지 소문자로 바뀝니다. { JAVA -> Java }
- 레파지토리 등록시 옵션 버튼을 추가 했습니다.

#230 해당 내용 수정 테스트 진행후 정상 작동 확인했습니다. 이 리퀘스트에는 해당 내용이 **포함 되어있지** 않습니다. 