### PR TITLE
feat: PCCP 모의고사 및 기출문제 로더 실행 추가

### DIFF
--- a/scripts/programmers/programmers.js
+++ b/scripts/programmers/programmers.js
@@ -12,6 +12,11 @@ const currentUrl = window.location.href;
 // 프로그래머스 연습 문제 주소임을 확인하고, 맞다면 로더를 실행
 if (currentUrl.includes('/learn/courses/30') && currentUrl.includes('lessons')) startLoader();
 
+// 프로그래머스 PCCP 모의고사(1,2회) 및 기출문제
+if (currentUrl.includes('/learn/courses/20847') && currentUrl.includes('lessons')) startLoader();
+if (currentUrl.includes('/learn/courses/20848') && currentUrl.includes('lessons')) startLoader();
+if (currentUrl.includes('/learn/courses/19344') && currentUrl.includes('lessons')) startLoader();
+
 function startLoader() {
   loader = setInterval(async () => {
     // 기능 Off시 작동하지 않도록 함


### PR DESCRIPTION
## 작업 요약
프로그래머스 코딩테스트 연습 문제들은 `startLoader`가 잘 실행되지만
PCCP 모의고사(1,2회) 및 기출문제는 실행되지 않는 것으로 확인하였습니다.
최근 프로그래머스에 **PCCP - 프로그래머스인증시험** 이 도입되면서 새롭게 생긴 문제들이기 때문에 Url이 기존 문제 모음 페이지와 달라 생긴 문제인 것 같습니다.

## 작업 내용
* PCCP 모의고사(1,2회) 및 기출문제 페이지에 대한 로더 실행 로직 추가

  * `'/learn/courses/20847'` 모의고사 1회
  * `'/learn/courses/20848'` 모의고사 2회
  * `'/learn/courses/19344'` 기출문제

## 작업 결과
<img width="500" alt="KakaoTalk_Photo_2024-02-06-15-36-48" src="https://github.com/BaekjoonHub/BaekjoonHub/assets/46295659/9d48fd49-4407-417d-91dd-ad74e2be6c4c"><br>
<img width="500" alt="KakaoTalk_Photo_2024-02-06-15-40-04" src="https://github.com/BaekjoonHub/BaekjoonHub/assets/46295659/eebac444-0ba8-4be8-a98a-13c6f287ccd6">



## 관련 스크린샷
> 프로그래머스인증시험 샘플문제 

<img width="500" alt="KakaoTalk_Photo_2024-02-06-15-26-07" src="https://github.com/BaekjoonHub/BaekjoonHub/assets/46295659/5fd3ea79-157f-4929-ab35-b7217aaad676"><br><br> 

  
> 기존 연습문제 Url : `/learn/courses/30`

<img width="500" alt="image" src="https://github.com/BaekjoonHub/BaekjoonHub/assets/46295659/c78d79a2-acda-4003-980a-b90e60f1d494"><br><br>
  
  
> PCCP Url : `'/learn/courses/20847'`, `'/learn/courses/20848'`, `'/learn/courses/19344'`

<img width="500" alt="KakaoTalk_Photo_2024-02-06-15-28-59" src="https://github.com/BaekjoonHub/BaekjoonHub/assets/46295659/e2f64d17-bda9-4dee-ac19-5da77861f057">




## 관련 링크
[샘플 문제 | 프로그래머스인증시험](https://certi.programmers.co.kr/about/sample)

related issue : #236 