### PR TITLE
Fix: 백준 문제풀이 후 세부 티어가 포함된 디렉토리로 푸시 되는 에러 해결

### DIFF
--- a/scripts/baekjoon/parsing.js
+++ b/scripts/baekjoon/parsing.js
@@ -46,7 +46,7 @@ async function makeDetailMessageAndReadme(data) {
     code, language, memory, runtime } = data;
   const score = parseNumberFromString(result);
   const directory = await getDirNameByOrgOption(
-    `백준/${level.replace(/ .*!/, '')}/${problemId}. ${convertSingleCharToDoubleChar(title)}`,
+    `백준/${level.replace(/ .*/, '')}/${problemId}. ${convertSingleCharToDoubleChar(title)}`,
     langVersionRemove(language, null)
   );
   const message = `[${level}] Title: ${title}, Time: ${runtime} ms, Memory: ${memory} KB`


### PR DESCRIPTION

백준 문제풀이 후 세부 티어가 포함된 디렉토리로 푸시되는 문제를 발견하였습니다.

baekjoon/parsing.js 의 49번째 줄에서 

디렉토리 경로를 파싱하는 과정에서 세부티어의 파싱이 누락되는 문제를 해결하였습니다.

#239  - 관련이슈