### PR TITLE
fix: 프로그래머스 풀이시간 파싱 수정

### DIFF
--- a/scripts/programmers/parsing.js
+++ b/scripts/programmers/parsing.js
@@ -34,7 +34,7 @@ async function parseData() {
     .map((x) => x.innerText)
     .map((x) => x.replace(/[^., 0-9a-zA-Z]/g, '').trim())
     .map((x) => x.split(', '))
-    .reduce((x, y) => (Number(x[0]) > Number(y[0]) ? x : y), ['0.00ms', '0.0MB'])
+    .reduce((x, y) => (Number(x[0].slice(0, -2)) > Number(y[0].slice(0, -2)) ? x : y), ['0.00ms', '0.0MB'])
     .map((x) => x.replace(/(?<=[0-9])(?=[A-Za-z])/, ' '));
 
   /*프로그래밍 언어별 폴더 정리 옵션을 위한 언어 값 가져오기*/


### PR DESCRIPTION
현재 Number("0.01ms") -> NAN 반환으로 풀이시간 비교가 제대로 되지 않고 있어, ms부분을 제외하고 계산하도록 수정한 부분 반영 요청드립니다.