### PR TITLE
feat: 구름레벨 커밋 메세지에 문제 난이도 추가

### DIFF
--- a/scripts/goormlevel/parsing.js
+++ b/scripts/goormlevel/parsing.js
@@ -14,7 +14,8 @@ async function parseData() {
 
   const examSequence = Number(pathnameList[2]) || 0;
   const quizNumber = Number(pathnameList[5]) || 0;
-  const difficulty = document.querySelectorAll('#ratingTooltipTarget > div > label').length;
+  const difficultyLabel = document.querySelector('span[role=text] > span').innerHTML;
+  const difficulty = difficultyLabels[difficultyLabel];
 
   const titlePrefix = 'title-';
   const title = document.querySelector(`div[aria-label^="${titlePrefix}"]`).ariaLabel.replace(titlePrefix, '');
@@ -107,8 +108,8 @@ async function makeData({
   runtime,
 }) {
   const languageExtension = languages[language.toLowerCase()];
-  const directory = await getDirNameByOrgOption(`goormlevel/${examSequence}/${quizNumber}. ${convertSingleCharToDoubleChar(title)}`, language);
-  const message = `[goormlevel] Title: ${title}, Time: ${runtime}, Memory: ${memory}, Difficulty: ${difficulty} -BaekjoonHub`;
+  const directory = await getDirNameByOrgOption(`goormlevel/${difficulty}/${examSequence}/${quizNumber}. ${convertSingleCharToDoubleChar(title)}`, language);
+  const message = `[난이도 ${difficulty}] Title: ${title}, Time: ${runtime}, Memory: ${memory}, Difficulty: ${difficulty} -BaekjoonHub`;
   const fileName = `${convertSingleCharToDoubleChar(title)}.${languageExtension}`;
   const dateInfo = getDateString(new Date(Date.now()));
   // prettier-ignore

--- a/scripts/goormlevel/variables.js
+++ b/scripts/goormlevel/variables.js
@@ -3,6 +3,7 @@
 /* 포함된 변수는 다음과 같습니다. 
     languages: goormlevel에서 제공하는 프로그래밍 언어에 맞는 file extension
     uploadState: 현재 업로드 중인지를 저장하는 boolean입니다.
+    difficultyLabels: 문제의 난이도를 숫자로 매핑하는 상수입니다.
 */
 
 /* state of upload for progress */
@@ -46,4 +47,12 @@ const languages = /** @type {const} */ ({
     "cobol": "cob",
     "d": "d",
     "erlang": "erl"
+});
+
+const difficultyLabels = /** @type {const} */ ({
+  '매우 쉬움': 1,
+  쉬움: 2,
+  보통: 3,
+  어려움: 4,
+  '매우 어려움': 5,
 });


### PR DESCRIPTION
안녕하세요 :) 백준허브를 유용하게 사용하고 있는 유저 중 한 명입니다.
다른 사이트와 달리 구름레벨 사용 시 커밋 메세지에 문제 난이도가 보이지 않다보니 불편함이 느껴졌습니다.
이를 개선하고자 구름레벨의 커밋 메세지에 난이도를 추가하였습니다.
이 과정에서 기존 구름레벨에서 문제 내 난이도 표시 하는 부분이 변경되어 수정하였습니다.

- 기존 커밋 메세지
<img width="406" alt="Screenshot 2024-08-20 at 23 43 15" src="https://github.com/user-attachments/assets/78aa5ebd-0756-4bee-99a7-80adb44f679d">

- 변경된 커밋 메세지
<img width="392" alt="Screenshot 2024-08-20 at 23 42 51" src="https://github.com/user-attachments/assets/b019431e-570f-4385-b79b-9e76cf1d45e0">

아무래도 구름레벨 자체의 폴더구조가 복잡한 부분이 있기에 커밋 메세지를 통해서라도 난이도를 보여야 조금이라도 더 명확한 분류가 될 수 있을 것이란 이유로 진행해보았습니다 :) 폴더 구조 개선에 있어서도 고민이 되는 포인트네요!