### PR TITLE
feat: 푸시할 디렉토리 경로 설정 기능 추가

### DIFF
--- a/scripts/baekjoon/parsing.js
+++ b/scripts/baekjoon/parsing.js
@@ -45,7 +45,7 @@ async function makeDetailMessageAndReadme(data) {
     problem_description, problem_input, problem_output, submissionTime,
     code, language, memory, runtime } = data;
   const score = parseNumberFromString(result);
-  const directory = await getDirNameByOrgOption(
+  const directory = await getDirNameByPushDirOption(
     `백준/${level.replace(/ .*/, '')}/${problemId}. ${convertSingleCharToDoubleChar(title)}`,
     langVersionRemove(language, null)
   );

--- a/scripts/goormlevel/parsing.js
+++ b/scripts/goormlevel/parsing.js
@@ -108,7 +108,7 @@ async function makeData({
   runtime,
 }) {
   const languageExtension = languages[language.toLowerCase()];
-  const directory = await getDirNameByOrgOption(`goormlevel/${examSequence}/${quizNumber}. ${convertSingleCharToDoubleChar(title)}`, language);
+  const directory = await getDirNameByPushDirOption(`goormlevel/${examSequence}/${quizNumber}. ${convertSingleCharToDoubleChar(title)}`, language);
   const message = `[난이도 ${difficulty}] Title: ${title}, Time: ${runtime}, Memory: ${memory} -BaekjoonHub`;
   const fileName = `${convertSingleCharToDoubleChar(title)}.${languageExtension}`;
   const dateInfo = getDateString(new Date(Date.now()));

--- a/scripts/programmers/parsing.js
+++ b/scripts/programmers/parsing.js
@@ -45,7 +45,7 @@ async function parseData() {
 
 async function makeData(origin) {
   const { problem_description, problemId, level, result_message, division, language_extension, title, runtime, memory, code, language } = origin;
-  const directory = await getDirNameByOrgOption(`프로그래머스/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`, language);
+  const directory = await getDirNameByPushDirOption(`프로그래머스/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`, language);
   const levelWithLv = `${level}`.includes('lv') ? level : `lv${level}`.replace('lv', 'level ');
   const message = `[${levelWithLv}] Title: ${title}, Time: ${runtime}, Memory: ${memory} -BaekjoonHub`;
   const fileName = `${convertSingleCharToDoubleChar(title)}.${language_extension}`;

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -163,6 +163,28 @@ async function getOrgOption() {
   }
 }
 
+/** Returns the value set in push_dir_option in welcome.html. */
+async function getPushDirOption() {
+  try {
+    return await getObjectFromLocalStorage('BaekjoonHub_PushDirOption');
+  } catch (ex) {
+    console.log('The way it works has changed with updates. Update your storage. ');
+    chrome.storage.local.set({ BaekjoonHub_PushDirOption: 'root' }, () => {});
+    return 'root';
+  }
+}
+
+/** Returns the value of the custom push_dir_path. */
+async function getPushDirPath() {
+  try {
+    return await getObjectFromLocalStorage('BaekjoonHub_PushDirPath');
+  } catch (ex) {
+    console.log('The way it works has changed with updates. Update your storage. ');
+    chrome.storage.local.set({ BaekjoonHub_PushDirPath: null }, () => {});
+    return null;
+  }
+}
+
 async function getModeType() {
   return await getObjectFromLocalStorage('mode_type');
 }
@@ -266,6 +288,16 @@ async function getDirNameByOrgOption(dirName, language) {
   return dirName;
 }
 
+/**
+ * 해당 메서드는 푸시 디렉토리 커스텀 옵션을 사용할 경우 푸시할 디렉토리를 지정하기 위함입니다.
+ * 스토리지에 저장된 {@link getPushDirOption}값에 따라 분기 처리됩니다.
+ * */
+async function getDirNameByPushDirOption(dirName, language) {
+  dirName = await getDirNameByOrgOption(dirName, language);
+  const pushDirPath = await getPushDirPath();
+  if ((await getPushDirOption()) === 'custom' && pushDirPath) dirName = `${pushDirPath}/${dirName}`;
+  return dirName;
+}
 
 /**
  * @deprecated

--- a/scripts/swexpertacademy/parsing.js
+++ b/scripts/swexpertacademy/parsing.js
@@ -89,7 +89,7 @@ async function makeData(origin) {
   * C++ 같은 경우에는 문자가 그대로 유지됩니다.
   * */
   const lang = (language === language.toUpperCase()) ? language.substring(0, 1) + language.substring(1).toLowerCase() : language
-  const directory = await getDirNameByOrgOption(`SWEA/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`, lang);
+  const directory = await getDirNameByPushDirOption(`SWEA/${level}/${problemId}. ${convertSingleCharToDoubleChar(title)}`, lang);
   const message = `[${level}] Title: ${title}, Time: ${runtime}, Memory: ${memory} -BaekjoonHub`;
   const fileName = `${convertSingleCharToDoubleChar(title)}.${extension}`;
   const dateInfo = submissionTime ?? getDateString(new Date(Date.now()));

--- a/welcome.html
+++ b/welcome.html
@@ -36,6 +36,16 @@
           </select>
         </div>
 
+        <!-- Directory setting options for push -->
+        <div class="field">
+          <select id="push_dir_option">
+            <!-- Root Directory -->
+            <option value="root">Push to Root Directory</option>
+            <!-- Custom Directory -->
+            <option value="custom">Push to Custom Directory</option>
+          </select>
+        </div>
+
         <!-- 프로그래밍 언어별 폴더 정리 옵션 -->
         <div class="field">
           <select id="org_option">
@@ -52,6 +62,10 @@
       <div class="ui form">
         <div class="field">
           <input autocomplete="off" id="name" placeholder="Repository Name" type="text" />
+        </div>
+        <!-- Custom Directory Path Input Field -->
+        <div style="display: none" class="field" id="custom_dir_input">
+          <input autocomplete="off" id="push_dir_path" placeholder="Directory Path" type="text" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
안녕하세요! 좋은 익스텐션 개발해주셔서 감사합니다!
백준허브를 이용해 알고리즘 스터디를 진행하고 있는데, 한 레포지토리에 스터디원별로 디렉토리를 만들어 문제를 관리하는 기능이 필요하여 푸시할 디렉토리를 커스텀 할 수 있는 기능을 간단히 구현해보았습니다.

## 작업내용
- 최초 깃허브 연동 페이지에 푸시할 디렉토리를 커스텀할 수 있는 드롭박스 추가
- 디폴트 값은 기존과 동일한 루트 디렉토리로 지정
- 정규표현식으로 경로를 검증해 올바르지 않은 경로 입력시 에러 표시 ('/'가 맨 앞 혹은 맨 뒤에 있는 경우, '/'가 연속으로 두번 등장하는 경우 등)
- 사용자가 입력한 커스텀 경로를 크롬 로컬 스토리지에 저장 후, parsing.js에서 문제의 디렉토리를 파싱할 때 사용자의 커스텀 경로를 추가
- 언어별 폴더 분기 기능과 호환되도록 구현 (사용자 커스텀 경로를 최상위 경로로 지정)

## 테스트 결과
<img width="1129" alt="스크린샷 2025-01-30 오후 3 42 08" src="https://github.com/user-attachments/assets/ca58e8e0-7ce6-4fec-8550-d83d40bac40e" />

<img width="1164" alt="스크린샷 2025-01-30 오전 4 48 21" src="https://github.com/user-attachments/assets/b8e68b87-07f8-4ffd-bdea-294733e5a97c" />

<img width="919" alt="스크린샷 2025-01-30 오전 5 30 39" src="https://github.com/user-attachments/assets/4b65f0b0-b992-4d08-931e-7b27fb6290b1" />

<img width="1267" alt="스크린샷 2025-01-30 오전 5 30 57" src="https://github.com/user-attachments/assets/0c002cde-fb2c-4c02-b7b2-e62bf847864e" />