### PR TITLE
fix: 구름레벨 정답 제출 후 푸시가 되지 않는 문제 수정

### DIFF
--- a/scripts/goormlevel/goormlevel.js
+++ b/scripts/goormlevel/goormlevel.js
@@ -38,7 +38,7 @@ function stopLoader() {
 }
 
 function getSolvedResult() {
-  const activeSubmitTab = [...document.querySelectorAll('#FrameBody li.nav-item > a.nav-link.active')].find(($element) => $element.textContent === '제출결과');
+  const activeSubmitTab = [...document.querySelectorAll('#FrameBody li.nav-item > a.nav-link.active')].find(($element) => $element.textContent === '제출 결과');
 
   if (!!activeSubmitTab) {
     const result = [...document.querySelectorAll('#FrameBody div > p[class] > span')].find(($element) => $element.textContent === '정답입니다.');


### PR DESCRIPTION
## 문제상황
구름레벨에서 정답 제출 후, 정답처리가 되었음에도 불구하고 자동 푸시가 되지 않는 문제가 발생하였습니다.

## 원인
goormlevel.js의 getSolvedResult 함수에서 HTML에서 텍스트가 '제출결과' 인 요소를 찾는 부분에서 문제가 발생한 것 같습니다.
구름레벨 사이트의 HTML 구조가 변경되어 기존 '제출결과' 탭이 '제출 결과' 탭으로 변경되어 발생한 문제로 보입니다.

<img width="350" alt="스크린샷 2025-01-30 오후 3 07 43" src="https://github.com/user-attachments/assets/72cce60b-309c-4b4f-949a-feef42aa3997" />

## 해결방법
텍스트가 '제출 결과' 인 요소를 찾도록 변경하여 간단히 해결하였습니다.