### PR TITLE
fix(goorm): handle new div-based editor structure in parseData

### DIFF
--- a/src/scripts/goormlevel/parsing.js
+++ b/src/scripts/goormlevel/parsing.js
@@ -25,7 +25,25 @@ async function parseData() {
 
   const languageList = [...document.querySelectorAll('#FrameBody .Tour__selectLang div[role="menu"] button[role="menuitem"]')].map(($element) => $element.textContent);
   const currentLanguageIndex = languageList.findIndex((language) => currentLanguage === language);
-  const code = [...document.querySelectorAll('#fileEditor textarea[readonly]')].map(($element) => $element.value)[currentLanguageIndex] || '';
+  
+  const editors = document.querySelectorAll("#fileEditor div.cm-content.cm-lineWrapping");
+
+  // 대상 에디터 결정
+  const targetIndex =
+    currentLanguageIndex >= 0 && currentLanguageIndex < editors.length
+      ? currentLanguageIndex
+      : editors.length === 1 && currentLanguageIndex < 0
+      ? 0
+      : -1;
+
+  // 코드 추출
+  const code =
+    targetIndex >= 0
+      ? Array.from(editors[targetIndex].querySelectorAll("div.cm-line"))
+          .map((line) => line.textContent)
+          .join("\n")
+      : "";
+
 
   const $dataList = [...document.querySelectorAll('.tab-content .tab-pane.active table tbody tr')].filter(($element) => $element.childNodes[1].textContent === 'PASS');
   const { memory, runtime } = $dataList


### PR DESCRIPTION
문제 상황
현상: GoormLEVEL 문제 제출 시 자동 업로드 기능이 동작하지 않았습니다. 스피너나 오류 메시지 없이 조용히 실패했습니다.
버전: 백준허브 확장 프로그램 v1.2.5

원인 분석
상세 디버깅 결과, scripts/goormlevel/parsing.js의 parseData() 함수가 GoormLEVEL의 변경된 에디터 구조 때문에 소스 코드를 제대로 추출하지 못하는 것을 확인했습니다. 기존의 textarea 기반 에디터가 div 기반의 CodeMirror 에디터로 변경되면서, 코드 추출 로직이 빈 문자열을 반환하여 업로드 절차가 시작되지 않았습니다.

해결 방법
새로운 에디터의 DOM 구조(div.cm-content.cm-lineWrapping)에 맞게 셀렉터를 수정하고, currentLanguageIndex를 활용하여 현재 활성화된 언어의 코드를 정확히 추출하도록 로직을 개선했습니다.

테스트 결과
로컬에서 수정한 코드로 테스트한 결과, 업로드 기능이 정상적으로 동작하고 스피너가 나타난 후 GitHub에 성공적으로 업로드되는 것을 확인했습니다.