### PR TITLE
fix: 패치노트 링크 수정

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="css/popup.css" />
+    <script src="/library/jquery-3.3.1.min.js"></script>
+
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css" rel="stylesheet" />
+    <script src="/library/semantic.min.js"></script>
+  </head>
+
+  <body>
+    <div class="ui grid container">
+      <div class="sixteen wide center aligned column">
+        <h1 id="title">Baekjoon<span style="color: #0078c3">Hub</span></h1>
+        <p id="caption">Sync your code from BOJ to GitHub</p>
+        <br />
+        <!-- Authentication mode -->
+        <div id="auth_mode" hidden>
+          <p class="onboarding">
+            <br />
+            Authenticate with GitHub to use
+            <strong>Baekjoon<span style="color: #f18500">Hub</span></strong>
+          </p>
+          <button id="authenticate" class="ui secondary button">
+            <i class="icon github"></i>
+            Authenticate
+          </button>
+        </div>
+
+        <!-- Repo Hook mode -->
+        <div id="hook_mode" hidden>
+          <p class="onboarding">
+            <br />
+            Set up repository hook to use
+            <strong>Baekjoon<span style="color: #0078c3">Hub</span></strong>
+          </p>
+          <a id="hook_URL" href="" target="blank" class="ui secondary button">
+            <i class="icon github"></i>
+            Set up Hook
+          </a>
+        </div>
+
+        <div id="commit_mode" hidden>
+          <p id="repo_url" class="ui small header" style="margin-top: 5px; margin-bottom: 6px !important"></p>
+          <div class="ui small header" style="margin-bottom: 5px; margin-top: 0px !important">
+            Want more features?
+            <a style="color: rgb(10, 89, 92) !important" target="_blank" href="https://github.com/BaekjoonHub/BaekjoonHub/labels/feature">Request a feature!</a>
+          </div>
+        </div>
+
+        <!-- 기능 on/off -->
+        <div style="margin-top: 10px">
+          <input type="checkbox" id="onffbox" />
+          <label for="onffbox" id="onffmain">
+            <span id="onffball"></span>
+          </label>
+        </div>
+      </div>
+
+      <!-- Generate Socials -->
+      <div id="socials" class="sixteen wide column">
+        <a title="BaekjoonHub GitHub" href="https://github.com/BaekjoonHub/BaekjoonHub" target="_blank"><i class="ui black github icon"></i></a>
+        <a title="Email" href="mailto:flaxinger@gmail.com" target="_blank"><i class="ui red envelope icon"></i></a>
+        <a title="Patch Notes" href="https://github.com/BaekjoonHub/BaekjoonHub/releases/latest" target="_blank"><i class="ui list alternate outline icon"></i></a>
+        <a title="BaekjoonHub Home" id="welcome_URL" href="" target="_blank"><i class="ui grey home icon"></i></a>
+      </div>
+    </div>
+
+    <script src="scripts/oauth2.js"></script>
+    <script type="text/javascript" src="popup.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
### 문제상황
---
팝업페이지내의 패치노트 버튼의 링크가 "https://github.com/BaekjoonHub/BaekjoonHub/blob/v.1.0.2/Patch_Notes/1.0.2.md"와 같이
잘못된 경로로 설정되어있습니다.

### 해결법
---
최신 릴리즈 페이지로 가도록 수정했습니다,