### PR TITLE
Project 환경이 Windows에서 호환되지 않는 문제 관련 제안

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "Node.js",
+  // "Officially" maintained node devcontainer image from Microsoft
+  // https://github.com/devcontainers/templates/tree/main/src/javascript-node
+  // https://mcr.microsoft.com/en-us/artifact/mar/devcontainers/javascript-node/tags
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-18-bookworm",
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {}
+  },
+
+  "postCreateCommand": "npm ci",
+}


### PR DESCRIPTION
---
name: Pull Request
about: suggest devcontainer for windows
title: Project 환경이 Windows에서 호환되지 않는 문제 관련 제안
labels: internal
assignees: NERDHEAD-lab
---

# feature/suggest-devcontainer-for-windows


## 변경 사항 요약
vscode, webstorm 등에서 플러그인으로 제공하는 devcontainer 설정 추가

### example
설정
<img width="786" height="593" alt="image" src="https://github.com/user-attachments/assets/15e52d18-7dbd-47c3-8b28-11ad9d58a600" />

windows에서 오류 없이 package의 build.sh가 수행됨
<img width="2055" height="993" alt="image" src="https://github.com/user-attachments/assets/9560675e-cf66-4ce1-abea-13457f3bf03e" />


## devcontainer 설정 추가
- e012461 - internal: add devcontainer env



## TODO 
- [ ] devcontainer 테스트