### PR TITLE
fix: Firefox에서 GitHub 이슈 페이지 접속 오류 수정

### DIFF
--- a/src/rules.json
+++ b/src/rules.json
@@ -1,14 +1,17 @@
 [
-    {
-        "id": 1,
-        "priority": 1,
-        "action": {
-          "type": "modifyHeaders",
-          "requestHeaders": [
-            { "header": "sec-fetch-dest", "operation": "set", "value": "document" },
-            { "header": "sec-fetch-mode", "operation": "set", "value": "navigate" }
-          ]
-        },
-        "condition": { "domains":["acmicpc.net"], "resourceTypes": ["xmlhttprequest"] }
+  {
+    "id": 1,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        { "header": "sec-fetch-dest", "operation": "set", "value": "document" },
+        { "header": "sec-fetch-mode", "operation": "set", "value": "navigate" }
+      ]
+    },
+    "condition": {
+      "initiatorDomains": ["acmicpc.net"],
+      "resourceTypes": ["xmlhttprequest"]
     }
+  }
 ]


### PR DESCRIPTION
# fix/309-dnr-firefox-compatibility

Fixes #309

## 변경 사항 요약

Firefox 기반 브라우저(Zen Browser 등)에서 GitHub 이슈 페이지 접속 시 422 에러가 발생하는 문제를 수정했습니다.

### 원인

`declarativeNetRequest` 규칙에서 deprecated된 `domains` 필드를 사용하고 있었는데, Firefox에서는 이 필드가 제대로 인식되지 않아 **모든 도메인**의 XHR 요청에 헤더 수정 규칙이 적용되었습니다.

이로 인해 GitHub의 내부 GraphQL 요청에 `Sec-Fetch-Mode: navigate` 헤더가 추가되어 422 에러가 발생했습니다.

| 깃허브에 존재하는 모든 레포의 이슈 페이지에서 발생 |
| --- |
| <img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/d72eb23b-f59c-4d2c-a388-6ee884cb60cd" /> |

### 해결
- `domains` (deprecated) → `initiatorDomains` (표준 API)로 변경
- Chrome 101+, Firefox 모두 지원되는 표준 필드 사용

## 커밋 내역 요약
- commit: eb1e163 - fix: declarativeNetRequest 규칙의 Firefox 호환성 문제 수정

## Firefox 테스트 방법

> ⚠️ 현재 `manifest.json`이 Chrome 전용(`service_worker`)으로 작성되어 있어, Firefox에서 테스트하려면 아래와 같은 작업을 진행

### 1. manifest.json 수정

```diff
// src/manifest.json
  "background": {
-   "service_worker": "scripts/commons/background.ts",
+   "scripts": ["scripts/commons/background.ts"],
    "type": "module"
  },
```

### 2. 빌드

```bash
npm run build
```

### 3. Firefox에 확장 프로그램 로드

1. Firefox 주소창에 about:debugging 입력
2. 좌측 메뉴에서 "This Firefox" (또는 "This Zen") 클릭
3. "임시 부가 기능 로드..." (또는 "Load Temporary Add-on...") 버튼 클릭
4. 빌드된 dist 폴더 내의 manifest.json 파일 선택 (또는 packages/baekjoonhub-v2.0.0.zip 파일 선택)

## TODO 
- [ ] Firefox 기반 브라우저에서 GitHub 이슈 페이지 정상 동작 확인
- [ ] Firefox 기반 브라우저에서 백준 문제 제출 및 GitHub 업로드 정상 동작 확인
- [ ] Chrome에서 백준 문제 제출 및 GitHub 업로드 정상 동작 확인
- [ ] 프로그래머스에서 정상 동작 확인 (선택)
- [ ] SW Expert Academy에서 정상 동작 확인 (선택)

## 참고 사항
- acmicpc.net 도메인만 허용되어 있었기에 필드만 변경했지만 경우에 따라 다른 PS 도메인들도 추가해야 할 수도 있습니다
- 메인테이너의 수정도 환영합니다

## 추가 요청

현재 Firefox Add-on Store에는 v1.0.1만 배포되어 있는 것으로 보입니다
이 PR이 머지되면 Firefox Add-on Store에도 업데이트 배포를 부탁드려도 될까요?
다만 Firefox 배포 시에는 `manifest.json`의 `background.service_worker` → `background.scripts` 변경이 필요합니다