### PR TITLE
fix: 로컬 캐시 부재 시 발생하는 중복 커밋 문제 해결 (전체 플랫폼 적용)

### DIFF
--- a/scripts/Github.js
+++ b/scripts/Github.js
@@ -208,3 +208,24 @@ async function getTree(hook, token) {
       return data.tree;
     });
 }
+
+/** get a file from the repository
+ * @see https://docs.github.com/en/rest/repos/contents#get-repository-content
+ * @param {string} hook - the github repository
+ * @param {string} token - the github token
+ * @param {string} path - the file path
+ * @return {Promise} - the promise for the file object or null if not found
+ */
+async function getFile(hook, token, path) {
+  return fetch(`https://api.github.com/repos/${hook}/contents/${path}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `token ${token}`,
+      Accept: 'application/vnd.github.v3+json',
+    },
+  })
+    .then((res) => {
+      if (res.status === 404) return null; // 파일이 존재하지 않는 경우
+      return handleGitHubResponse(res);
+    });
+}

--- a/scripts/baekjoon/baekjoon.js
+++ b/scripts/baekjoon/baekjoon.js
@@ -74,7 +74,7 @@ function stopLoader() {
   loader = null;
 }
 
-function toastThenStopLoader(toastMessage, errorMessage){
+function toastThenStopLoader(toastMessage, errorMessage) {
   Toast.raiseToast(toastMessage)
   stopLoader()
   throw new Error(errorMessage)
@@ -87,6 +87,7 @@ async function beginUpload(bojData) {
   if (!isNull(bojData) && isNotEmpty(bojData.code) && isNotEmpty(bojData.readme) && isNotEmpty(bojData.directory)) {
     const stats = await getStats();
     const hook = await getHook();
+    const token = await getToken();
 
     const currentVersion = stats.version;
     /* 버전 차이가 발생하거나, 해당 hook에 대한 데이터가 없는 경우 localstorage의 Stats 값을 업데이트하고, version을 최신으로 변경한다 */
@@ -100,6 +101,13 @@ async function beginUpload(bojData) {
     log('cachedSHA', cachedSHA, 'calcSHA', calcSHA)
 
     if (isNull(cachedSHA)) {
+      /* 로컬 캐시가 없는 경우 원격 저장소에서 파일 존재 여부 실시간 확인 */
+      const remoteFile = await getFile(hook, token, `${bojData.directory}/${bojData.fileName}`);
+      if (remoteFile && remoteFile.sha === calcSHA) {
+        markUploadedCSS(stats.branches, bojData.directory);
+        console.log('원격 저장소에 동일한 파일이 존재하여 업로드를 건너뜁니다.');
+        return;
+      }
       /* GitHub에서 파일이 삭제된 경우, 새 업로드로 처리 */
       console.log('캐시된 SHA가 없습니다. 새로 업로드합니다.');
     } else if (cachedSHA == calcSHA) {
@@ -152,7 +160,7 @@ function injectManualUploadButtons(currentUsername) {
   if (isEmpty(table)) return;
   for (const row of table) {
     const isAccepted = row.resultCategory === RESULT_CATEGORY.RESULT_ACCEPTED ||
-                       row.resultCategory === RESULT_CATEGORY.RESULT_PARTIALLY_ACCEPTED;
+      row.resultCategory === RESULT_CATEGORY.RESULT_PARTIALLY_ACCEPTED;
     if (!isAccepted) continue;
     if (row.username !== currentUsername) continue;
     const rowEl = document.getElementById(row.elementId);

--- a/scripts/goormlevel/goormlevel.js
+++ b/scripts/goormlevel/goormlevel.js
@@ -71,6 +71,7 @@ async function beginUpload(parsedData) {
     } = parsedData;
     const stats = await getStats();
     const hook = await getHook();
+    const token = await getToken();
 
     const currentVersion = stats.version;
     /* 버전 차이가 발생하거나, 해당 hook에 대한 데이터가 없는 경우 localstorage의 Stats 값을 업데이트하고, version을 최신으로 변경한다 */

--- a/scripts/goormlevel/goormlevel.js
+++ b/scripts/goormlevel/goormlevel.js
@@ -82,7 +82,18 @@ async function beginUpload(parsedData) {
     const cachedSHA = await getStatsSHAfromPath(`${hook}/${directory}/${fileName}`);
     const calcSHA = calculateBlobSHA(code);
     log('cachedSHA', cachedSHA, 'calcSHA', calcSHA);
-    if (cachedSHA == calcSHA) {
+
+    if (isNull(cachedSHA)) {
+      /* 로컬 캐시가 없는 경우 원격 저장소에서 파일 존재 여부 실시간 확인 */
+      const remoteFile = await getFile(hook, token, `${directory}/${fileName}`);
+      if (remoteFile && remoteFile.sha === calcSHA) {
+        markUploadedCSS(stats.branches, directory);
+        console.log('원격 저장소에 동일한 파일이 존재하여 업로드를 건너뜁니다.');
+        return;
+      }
+      /* GitHub에서 파일이 삭제되거나 없는 경우, 새 업로드로 처리 */
+      console.log('캐시된 SHA가 없습니다. 새로 업로드합니다.');
+    } else if (cachedSHA == calcSHA) {
       markUploadedCSS(stats.branches, directory);
       console.log(`현재 제출번호를 업로드한 기록이 있습니다. examId: ${examId}, quizNumber: ${quizNumber}`);
       return;

--- a/scripts/programmers/programmers.js
+++ b/scripts/programmers/programmers.js
@@ -77,6 +77,7 @@ async function beginUpload(bojData) {
 
     const stats = await getStats();
     const hook = await getHook();
+    const token = await getToken();
 
     const currentVersion = stats.version;
     /* 버전 차이가 발생하거나, 해당 hook에 대한 데이터가 없는 경우 localstorage의 Stats 값을 업데이트하고, version을 최신으로 변경한다 */
@@ -88,7 +89,18 @@ async function beginUpload(bojData) {
     cachedSHA = await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.fileName}`)
     calcSHA = calculateBlobSHA(bojData.code)
     log('cachedSHA', cachedSHA, 'calcSHA', calcSHA)
-    if (cachedSHA == calcSHA) {
+
+    if (isNull(cachedSHA)) {
+      /* 로컬 캐시가 없는 경우 원격 저장소에서 파일 존재 여부 실시간 확인 */
+      const remoteFile = await getFile(hook, token, `${bojData.directory}/${bojData.fileName}`);
+      if (remoteFile && remoteFile.sha === calcSHA) {
+        markUploadedCSS(stats.branches, bojData.directory);
+        console.log('원격 저장소에 동일한 파일이 존재하여 업로드를 건너뜁니다.');
+        return;
+      }
+      /* GitHub에서 파일이 삭제되거나 없는 경우, 새 업로드로 처리 */
+      console.log('캐시된 SHA가 없습니다. 새로 업로드합니다.');
+    } else if (cachedSHA == calcSHA) {
       markUploadedCSS(stats.branches, bojData.directory);
       console.log(`현재 제출번호를 업로드한 기록이 있습니다. problemIdID ${bojData.problemId}`);
       return;

--- a/scripts/swexpertacademy/swexpertacademy.js
+++ b/scripts/swexpertacademy/swexpertacademy.js
@@ -76,6 +76,7 @@ async function beginUpload(bojData) {
   if (isNotEmpty(bojData)) {
     const stats = await getStats();
     const hook = await getHook();
+    const token = await getToken();
 
     const currentVersion = stats.version;
     /* 버전 차이가 발생하거나, 해당 hook에 대한 데이터가 없는 경우 localstorage의 Stats 값을 업데이트하고, version을 최신으로 변경한다 */
@@ -87,7 +88,18 @@ async function beginUpload(bojData) {
     cachedSHA = await getStatsSHAfromPath(`${hook}/${bojData.directory}/${bojData.fileName}`)
     calcSHA = calculateBlobSHA(bojData.code)
     log('cachedSHA', cachedSHA, 'calcSHA', calcSHA)
-    if (cachedSHA == calcSHA) {
+
+    if (isNull(cachedSHA)) {
+      /* 로컬 캐시가 없는 경우 원격 저장소에서 파일 존재 여부 실시간 확인 */
+      const remoteFile = await getFile(hook, token, `${bojData.directory}/${bojData.fileName}`);
+      if (remoteFile && remoteFile.sha === calcSHA) {
+        markUploadedCSS(stats.branches, bojData.directory);
+        console.log('원격 저장소에 동일한 파일이 존재하여 업로드를 건너뜁니다.');
+        return;
+      }
+      /* GitHub에서 파일이 삭제되거나 없는 경우, 새 업로드로 처리 */
+      console.log('캐시된 SHA가 없습니다. 새로 업로드합니다.');
+    } else if (cachedSHA == calcSHA) {
       markUploadedCSS(stats.branches, bojData.directory);
       console.log(`현재 제출번호를 업로드한 기록이 있습니다. problemIdID ${bojData.problemId}`);
       return;


### PR DESCRIPTION
## 문제 상황
기기 변경, 브라우저 캐시 삭제 또는 시크릿 모드 사용 시
`chrome.storage.local` 데이터가 초기화됩니다.

이 상태에서 동일한 문제를 다시 업로드하면,
이미 GitHub 원격 저장소에 동일한 파일이 존재하더라도
이를 인지하지 못하고 **중복 커밋**이 생성됩니다.

## 수정 사항

- `scripts/Github.js`
  - GitHub API를 통해 파일 존재 여부와 SHA를 조회하는 `getFile` 함수 추가

- 플랫폼별 스크립트 (BJ, PRG, SWEA, Goorm)
  - 로컬 `cachedSHA`가 없는 경우에만 원격 조회 수행
  - 원격 SHA와 현재 코드(`calcSHA`)를 비교하여 동일한 경우 업로드 중단

## 기대 효과
- 동일 파일에 대한 중복 커밋 방지
- 불필요한 GitHub API 요청 감소
- 로컬 캐시가 존재하는 경우 기존 로직 유지

---

## 재현

1. 문제를 업로드한 뒤, 브라우저 캐시 삭제 또는 다른 환경에서 실행
2. 동일 문제 업로드 버튼 클릭

- **기존**: 원격에 동일 파일이 있어도 `cachedSHA`가 없으므로 중복 커밋 생성
- **수정 후**: 원격 SHA 검증을 통해 중복임을 인지하고 업로드 차단