### PR TITLE
feat: GitHub 업로드 실패 시 ZIP 파일로 폴백

### DIFF
--- a/scripts/baekjoon/uploadfunctions.js
+++ b/scripts/baekjoon/uploadfunctions.js
@@ -35,6 +35,8 @@ async function uploadOneSolveProblemOnGit(bojData, cb) {
  */
 async function uploadAllSolvedProblem() {
   const tree_items = [];
+  const zip = new JSZip();
+
   try {
     // 1. GitHub tree 동기화
     const stats = await updateLocalStorageStats();
@@ -86,6 +88,10 @@ async function uploadAllSolvedProblem() {
     const saveExamples = await getSaveExamplesOption();
     for (const bojData of bojDatas) {
       if (!isEmpty(bojData.code) && !isEmpty(bojData.readme)) {
+        zip
+          .folder(bojData.directory)
+          .file(bojData.fileName, bojData.code)
+          .file('README.md', bojData.readme);
         tree_items.push({
           path: `${bojData.directory}/${bojData.fileName}`,
           mode: '100644',
@@ -101,6 +107,9 @@ async function uploadAllSolvedProblem() {
         if (saveExamples && bojData.samples && bojData.samples.length > 0) {
           const fileEntries = samplesToFileEntries(bojData.samples);
           for (const entry of fileEntries) {
+            zip
+              .folder(bojData.directory)
+              .file(entry.filename, entry.content);
             tree_items.push({
               path: `${bojData.directory}/${entry.filename}`,
               mode: '100644',
@@ -129,7 +138,11 @@ async function uploadAllSolvedProblem() {
     console.error('전체 코드 업로드 실패', error);
     const msg = error?.message || String(error);
     MultiloaderFail(msg);
-    Toast.raiseToast(`전체 업로드 실패: ${msg}`);
+    // zip 파일로 폴백
+    const zipped = await zip.generateAsync({ type: 'blob' });
+    const filename = `baekjoon_backup_${Date.now()}.zip`;
+    saveAs(zipped, filename);
+    Toast.raiseToast(`전체 업로드 실패: ${msg}. 데이터를 zip 파일로 다운로드했습니다.`);
   }
 }
 

--- a/scripts/programmers/uploadfunctions.js
+++ b/scripts/programmers/uploadfunctions.js
@@ -66,6 +66,7 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
  */
 async function uploadAllSolvedProblemProgrammers() {
   const tree_items = [];
+  const zip = new JSZip();
   try {
     // 1. GitHub tree 동기화
     const stats = await updateLocalStorageStats();
@@ -94,6 +95,10 @@ async function uploadAllSolvedProblemProgrammers() {
     // 4. Tree 아이템 생성 (Blob 생성 API 호출을 줄이기 위해 content 직접 전달)
     for (const bojData of bojDatas) {
       if (!isEmpty(bojData.code) && !isEmpty(bojData.readme)) {
+        zip
+          .folder(bojData.directory)
+          .file(bojData.fileName, bojData.code)
+          .file('README.md', bojData.readme);
         tree_items.push({
           path: `${bojData.directory}/${bojData.fileName}`,
           mode: '100644',
@@ -125,5 +130,10 @@ async function uploadAllSolvedProblemProgrammers() {
     }
   } catch (error) {
     console.error('전체 코드 업로드 실패', error);
+    // zip 파일로 폴백
+    const zipped = await zip.generateAsync({ type: 'blob' });
+    const filename = `programmers_backup_${Date.now()}.zip`;
+    saveAs(zipped, filename);
+    Toast.raiseToast(`전체 업로드 실패: ${msg}. 데이터를 zip 파일로 다운로드했습니다.`);
   }
 }

--- a/scripts/swexpertacademy/uploadfunctions.js
+++ b/scripts/swexpertacademy/uploadfunctions.js
@@ -67,6 +67,7 @@ async function upload(token, hook, sourceText, readmeText, directory, filename, 
  */
 async function uploadAllSolvedProblemSWEA() {
   const tree_items = [];
+  const zip = new JSZip();
   try {
     // 1. GitHub tree 동기화
     const stats = await updateLocalStorageStats();
@@ -95,6 +96,10 @@ async function uploadAllSolvedProblemSWEA() {
     // 4. Tree 아이템 생성 (Blob 생성 API 호출을 줄이기 위해 content 직접 전달)
     for (const bojData of bojDatas) {
       if (!isEmpty(bojData.code) && !isEmpty(bojData.readme)) {
+        zip
+          .folder(bojData.directory)
+          .file(bojData.fileName, bojData.code)
+          .file('README.md', bojData.readme);
         tree_items.push({
           path: `${bojData.directory}/${bojData.fileName}`,
           mode: '100644',
@@ -126,5 +131,10 @@ async function uploadAllSolvedProblemSWEA() {
     }
   } catch (error) {
     console.error('전체 코드 업로드 실패', error);
+    // zip 파일로 폴백
+    const zipped = await zip.generateAsync({ type: 'blob' });
+    const filename = `swexpertacademy_backup_${Date.now()}.zip`;
+    saveAs(zipped, filename);
+    Toast.raiseToast(`전체 업로드 실패: ${msg}. 데이터를 zip 파일로 다운로드했습니다.`);
   }
 }


### PR DESCRIPTION
Probably resolves #330

GitHub API로 트리를 생성하는 경우 데이터가 너무 크면 422 Unprocessable Content 오류를 반환합니다.
이 PR은 GitHub API에 어떤 이유로든 오류가 발생하면 blob에 저장된 모든 데이터를 ZIP 파일로 만들어 다운로드합니다.
새롭게 추가된 라이브러리는 없으며, 어째서인지 이미 익스텐션에 번들로 포함된 JSZip과 FileSaver를 사용하였습니다.