### PR TITLE
fix: SWEA 자동 업로드 실패 수정 (#333)

### DIFF
--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -220,6 +220,8 @@ async function getStatsSHAfromPath(path) {
 }
 
 function getObjectDatafromPath(obj, path) {
+  // path/obj가 비어 있으면(예: hook 미설정) 경로 필터에서 예외가 발생하므로 안전하게 null 반환
+  if (isNull(obj) || isNull(path)) return null;
   let current = obj;
   const pathArray = _swexpertacademyRankRemoveFilter(_baekjoonSpaceRemoverFilter(_programmersRankRemoverFilter(_baekjoonRankRemoverFilter(path))))
     .split('/')

--- a/scripts/swexpertacademy/parsing.js
+++ b/scripts/swexpertacademy/parsing.js
@@ -19,6 +19,90 @@ function updateTextSourceEvent() {
   document.documentElement.removeAttribute('onreset');
 }
 
+/**
+ * 여러 개의 selector 후보를 순서대로 시도해 가장 먼저 매칭되는 요소를 반환합니다.
+ * SWEA DOM 구조 변경에 대비해 절대 경로 selector 대신 fallback 체인을 사용합니다.
+ * @param {string[]} selectors - 시도할 selector 목록 (우선순위 순)
+ * @param {ParentNode} [root=document] - 탐색 기준 노드
+ * @returns {Element|null}
+ */
+function querySelectorFallback(selectors, root = document) {
+  for (const selector of selectors) {
+    try {
+      const el = root.querySelector(selector);
+      if (!isNull(el)) return el;
+    } catch (e) {
+      /* 유효하지 않은 selector는 무시 */
+    }
+  }
+  return null;
+}
+
+/** 요소의 텍스트를 안전하게 추출합니다. null이면 빈 문자열을 반환합니다. */
+function safeText(el) {
+  return isNull(el) ? '' : (el.textContent || el.innerText || '').trim();
+}
+
+/** 조회 중인(검색창) 닉네임을 추출합니다. */
+function getSearchedNickname() {
+  const el = querySelectorFallback(['#searchinput', 'input[name="searchinput"]', 'input#searchinput']);
+  return (el?.value || '').trim();
+}
+
+/** 문제 번호를 여러 fallback으로 추출합니다. */
+function parseProblemId() {
+  // 1. 문제 박스 내 순수 문제번호 p (problem_title 클래스 제외)
+  let text = safeText(querySelectorFallback([
+    'div.problem_box > p:not(.problem_title)',
+    'body > div.container > div.container.sub > div > div.problem_box > p',
+  ]));
+  // 2. h3 ("1234. 제목 D2") 형태에서 추출
+  if (isEmpty(text)) {
+    text = safeText(querySelectorFallback(['div.problem_box > h3', 'div.problem_box h3']));
+  }
+  return text.split('.')[0].replace(/[^0-9]/g, '').trim();
+}
+
+/** contestProbId를 히든 input 우선, 없으면 URL 파라미터에서 추출합니다. */
+function parseContestProbId() {
+  const inputs = [...document.querySelectorAll('#contestProbId, input[name="contestProbId"]')];
+  for (let i = inputs.length - 1; i >= 0; i--) {
+    const v = (inputs[i].value || '').trim();
+    if (v) return v;
+  }
+  return (new URLSearchParams(window.location.search).get('contestProbId') || '').trim();
+}
+
+/** 제출 정보(언어/메모리/실행시간/코드길이)를 info 박스에서 추출합니다. */
+function parseSubmissionInfo(infoBox) {
+  let items = [...infoBox.querySelectorAll('ul > li')];
+  if (items.length === 0) items = [...infoBox.querySelectorAll('li')];
+  const pick = (li) => {
+    if (isNull(li)) return '';
+    return safeText(li.querySelector('span')) || safeText(li);
+  };
+  return {
+    language: pick(items[0]),
+    memory: pick(items[1]).toUpperCase(),
+    runtime: pick(items[2]),
+    length: pick(items[3]),
+  };
+}
+
+/** 제출 일시를 날짜 패턴 매칭으로 추출합니다. */
+function parseSubmissionTime() {
+  const datePattern = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}(:\d{2})?/;
+  const candidates = [
+    querySelectorFallback(['.smt_txt > dd', '.smt_txt dd', '.smt_txt']),
+    querySelectorFallback(['div.problem_box', '#problemForm']),
+  ];
+  for (const el of candidates) {
+    const m = safeText(el).match(datePattern);
+    if (m) return m[0];
+  }
+  return '';
+}
+
 /*
   문제 요약과 코드를 파싱합니다.
   - directory : 레포에 기록될 폴더명
@@ -28,51 +112,80 @@ function updateTextSourceEvent() {
   - code : 소스코드 내용
 */
 async function parseData() {
-  const nickname = document.querySelector('#searchinput').value;
+  const searchedNickname = getSearchedNickname();
+  const myNickname = getNickname();
+  log('SWEA 파싱 시작 - 로그인 유저:', myNickname, '조회 유저:', searchedNickname);
 
-  log('사용자 로그인 정보 및 유무 체크', nickname, document.querySelector('#problemForm div.info'));
-  // 검색하는 유저 정보와 로그인한 유저의 닉네임이 같은지 체크
-  // PASS를 맞은 기록 유무 체크
-  if (getNickname() !== nickname) return;
-  if (isNull(document.querySelector('#problemForm div.info'))) return;
+  // 검색 중인 유저와 로그인 유저가 다르면 업로드하지 않음
+  // (둘 중 하나라도 비어 있으면 selector 변동 가능성을 고려해 검사를 통과시킴)
+  if (myNickname && searchedNickname && myNickname !== searchedNickname) {
+    log('로그인 유저와 조회 유저가 달라 업로드를 건너뜁니다.');
+    return;
+  }
+
+  // 제출 정보(언어/메모리/시간/코드길이) 영역
+  const infoBox = querySelectorFallback(['#problemForm div.info', 'div.problem_box div.info', 'div.info']);
+  if (isNull(infoBox)) {
+    console.error('[BaekjoonHub] SWEA 제출 정보 영역(div.info)을 찾지 못했습니다. SWEA DOM 구조 변경 가능성이 있습니다.');
+    return;
+  }
 
   log('결과 데이터 파싱 시작');
 
-  const title = document
-    .querySelector('div.problem_box > p.problem_title')
-    .innerText.replace(/ D[0-9]$/, '')
+  // 문제 제목
+  const titleEl = querySelectorFallback(['div.problem_box > p.problem_title', 'div.problem_box p.problem_title', '.problem_title']);
+  let title = safeText(titleEl)
+    .replace(/ D[0-9]$/, '')
     .replace(/^[^.]*/, '')
-    .substr(1)
+    .replace(/^\./, '')
     .trim();
+  if (isEmpty(title)) {
+    // fallback: h3 ("1234. 제목 D2")에서 제목만 추출
+    title = safeText(querySelectorFallback(['div.problem_box > h3', 'div.problem_box h3']))
+      .replace(/ D[0-9]$/, '')
+      .replace(/^[^.]*\.?/, '')
+      .trim();
+  }
+
   // 레벨
-  const level = document.querySelector('div.problem_box > p.problem_title > span.badge')?.textContent || 'Unrated';
+  const level = safeText(querySelectorFallback([
+    'div.problem_box > p.problem_title > span.badge',
+    'div.problem_box p.problem_title span.badge',
+    'div.problem_box .badge',
+  ])) || 'Unrated';
+
   // 문제번호
-  const problemId = document.querySelector('body > div.container > div.container.sub > div > div.problem_box > p').innerText.split('.')[0].trim();
+  const problemId = parseProblemId();
   // 문제 콘테스트 인덱스
-  const contestProbId = [...document.querySelectorAll('#contestProbId')].slice(-1)[0].value;
+  const contestProbId = parseContestProbId();
+  if (isEmpty(problemId) || isEmpty(contestProbId)) {
+    console.error('[BaekjoonHub] SWEA 문제 번호/contestProbId 파싱에 실패했습니다.', { problemId, contestProbId });
+    return;
+  }
   // 문제 링크
   const link = `${window.location.origin}/main/code/problem/problemDetail.do?contestProbId=${contestProbId}`;
 
-  // 문제 언어, 메모리, 시간소요
-  const language = document.querySelector('#problemForm div.info > ul > li:nth-child(1) > span:nth-child(1)').textContent.trim();
-  const memory = document.querySelector('#problemForm div.info > ul > li:nth-child(2) > span:nth-child(1)').textContent.trim().toUpperCase();
-  const runtime = document.querySelector('#problemForm div.info > ul > li:nth-child(3) > span:nth-child(1)').textContent.trim();
-  const length = document.querySelector('#problemForm div.info > ul > li:nth-child(4) > span:nth-child(1)').textContent.trim();
+  // 문제 언어, 메모리, 시간소요, 코드길이
+  const { language, memory, runtime, length } = parseSubmissionInfo(infoBox);
+  if (isEmpty(language)) {
+    console.error('[BaekjoonHub] SWEA 제출 언어 파싱에 실패했습니다.');
+    return;
+  }
 
   // 확장자명
   const extension = languages[language.toLowerCase()];
 
   // 제출날짜
-  const submissionTime = document.querySelector('.smt_txt > dd').textContent.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}/g)[0];
-  // 로컬스토리지에서 기존 코드에 대한 정보를 불러올 수 없다면 코드 디테일 창으로 이동 후 제출하도록 이동
-  const data = await getProblemData(problemId);
+  const submissionTime = parseSubmissionTime();
+
+  // 로컬스토리지에서 제출 코드를 불러옴 (problemId 우선, 실패 시 contestProbId로 조회)
+  let data = await getProblemData(problemId);
+  if (isNull(data?.code)) {
+    data = await getProblemDataByContestProbId(contestProbId);
+  }
   log('data', data);
   if (isNull(data?.code)) {
-    // 기존 문제 데이터를 로컬스토리지에 저장하고 코드 보기 페이지로 이동
-    // await updateProblemData(problemId, { level, contestProbId, link, language, memory, runtime, length, extension });
-    // const contestHistoryId = document.querySelector('div.box-list > div > div > span > a').href.replace(/^.*'(.*)'.*$/, '$1');
-    // window.location.href = `${window.location.origin}/main/solvingProblem/solvingProblem.do?contestProbId=${contestProbId}`;
-    console.error('소스코드 데이터가 없습니다.');
+    console.error('[BaekjoonHub] 저장된 SWEA 소스코드 데이터가 없습니다.', { problemId, contestProbId });
     return;
   }
   const code = data.code;
@@ -99,7 +212,7 @@ async function makeData(origin) {
   });
   const message = `[${level}] Title: ${title}, Time: ${runtime}, Memory: ${memory} -BaekjoonHub`;
   const fileName = `${convertSingleCharToDoubleChar(title)}.${extension}`;
-  const dateInfo = submissionTime ?? getDateString(new Date(Date.now()));
+  const dateInfo = isEmpty(submissionTime) ? getDateString(new Date(Date.now())) : submissionTime;
   // prettier-ignore
   const readme =
     `# [${level}] ${title} - ${problemId} \n\n`

--- a/scripts/swexpertacademy/storage.js
+++ b/scripts/swexpertacademy/storage.js
@@ -49,3 +49,21 @@ async function updateProblemData(problemId, obj) {
 async function getProblemData(problemId) {
   return getObjectFromLocalStorage('swea').then((data) => data?.[problemId]);
 }
+
+/**
+ * contestProbId로 저장된 문제 데이터를 조회합니다.
+ * problemId selector가 변동되어 키 조회에 실패하는 경우의 fallback으로 사용합니다.
+ * @param {string} contestProbId 문제 콘테스트 인덱스
+ * @returns {object|undefined} 문제 내 데이터
+ */
+async function getProblemDataByContestProbId(contestProbId) {
+  if (isEmpty(contestProbId)) return undefined;
+  return getObjectFromLocalStorage('swea').then((data) => {
+    if (isNull(data)) return undefined;
+    for (const key of Object.keys(data)) {
+      const value = data[key];
+      if (!isNull(value) && String(value.contestProbId) === String(contestProbId)) return value;
+    }
+    return undefined;
+  });
+}

--- a/scripts/swexpertacademy/swexpertacademy.js
+++ b/scripts/swexpertacademy/swexpertacademy.js
@@ -29,8 +29,12 @@ if (currentUrl.includes('/main/userpage/code/userCode.do')) {
 function parseAndUpload() {
   //async wrapper
   (async () => {
-    const bojData = await parseData();
-    await beginUpload(bojData);
+    try {
+      const bojData = await parseData();
+      await beginUpload(bojData);
+    } catch (error) {
+      console.error('[BaekjoonHub] SWEA 파싱/업로드 중 오류가 발생했습니다.', error);
+    }
   })();
 }
 function startLoader() {
@@ -72,11 +76,24 @@ function stopLoader() {
 /* 파싱 직후 실행되는 함수 */
 async function beginUpload(bojData) {
   log('bojData', bojData);
-  startUpload();
+  /* 파싱 결과가 유효할 때만 로딩 UI를 띄우고 업로드를 진행한다.
+     파싱 실패 시 로딩 UI 없이 조용히 종료한다 (프로그래머스와 동일한 동작). */
   if (isNotEmpty(bojData)) {
+    startUpload();
     const stats = await getStats();
     const hook = await getHook();
     const token = await getToken();
+
+    /* GitHub 저장소(hook)/토큰/stats가 준비되지 않은 경우 크래시 대신 실패로 처리한다. */
+    if (isNull(hook) || isNull(token) || isNull(stats)) {
+      console.error('[BaekjoonHub] GitHub 저장소(hook)/토큰/stats가 준비되지 않아 업로드를 진행할 수 없습니다.', {
+        hasHook: !isNull(hook),
+        hasToken: !isNull(token),
+        hasStats: !isNull(stats),
+      });
+      markUploadFailedCSS();
+      return;
+    }
 
     const currentVersion = stats.version;
     /* 버전 차이가 발생하거나, 해당 hook에 대한 데이터가 없는 경우 localstorage의 Stats 값을 업데이트하고, version을 최신으로 변경한다 */
@@ -106,6 +123,8 @@ async function beginUpload(bojData) {
     }
     /* 신규 제출 번호라면 새롭게 커밋  */
     await uploadOneSolveProblemOnGit(bojData, markUploadedCSS);
+  } else {
+    console.error('[BaekjoonHub] SWEA 파싱 결과가 비어 있어 업로드를 진행하지 않습니다.');
   }
 }
 

--- a/scripts/swexpertacademy/util.js
+++ b/scripts/swexpertacademy/util.js
@@ -2,20 +2,26 @@
  * 로딩 버튼 추가
  */
 function startUpload() {
+  // getElementById는 미존재 시 null을 반환하므로 isNull로 체크해야 한다.
   let elem = document.getElementById('BaekjoonHub_progress_anchor_element');
-  if (elem !== undefined) {
+  if (isNull(elem)) {
     elem = document.createElement('span');
     elem.id = 'BaekjoonHub_progress_anchor_element';
     // elem.className = 'runcode-wrapper__8rXm';
     // elem.style = 'margin-left: 10px;padding-top: 0px;';
   }
   elem.innerHTML = `<div id="BaekjoonHub_progress_elem" class="BaekjoonHub_progress"></div>`;
-  const target = document.querySelector('div.box-list > div.box-list-inner > div.right_answer > span.btn_right');
+  const target = document.querySelector('div.box-list > div.box-list-inner > div.right_answer > span.btn_right')
+    || document.querySelector('div.box-list div.right_answer span.btn_right')
+    || document.querySelector('div.right_answer span.btn_right')
+    || document.querySelector('div.box-list-inner');
   if (!isNull(target)) {
     target.prepend(elem);
+    // 로딩 UI를 실제로 삽입한 경우에만 카운트다운을 시작한다.
+    startUploadCountDown();
+  } else {
+    console.error('[BaekjoonHub] SWEA 업로드 로딩 UI를 삽입할 위치를 찾지 못했습니다.');
   }
-  // start the countdown
-  startUploadCountDown();
 }
 /**
  * 업로드 완료 아이콘 표시 및 링크 생성
@@ -27,6 +33,7 @@ function startUpload() {
 function markUploadedCSS(branches, directory) {
   uploadState.uploading = false;
   const elem = document.getElementById('BaekjoonHub_progress_elem');
+  if (isNull(elem)) return;
   elem.className = 'markuploaded';
   const uploadedUrl = "https://github.com/" +
               Object.keys(branches)[0] + "/tree/" + 
@@ -43,6 +50,7 @@ function markUploadedCSS(branches, directory) {
 function markUploadFailedCSS() {
   uploadState.uploading = false;
   const elem = document.getElementById('BaekjoonHub_progress_elem');
+  if (isNull(elem)) return;
   elem.className = 'markuploadfailed';
 }
 
@@ -63,7 +71,12 @@ function startUploadCountDown() {
  * @returns {string} 유저 닉네임이며 없을 시에 null을 반환
  */
 function getNickname() {
-  return document.querySelector('#Beginner')?.innerText || document.querySelector('header > div > span.name')?.innerText || '';
+  const el = document.querySelector('#Beginner')
+    || document.querySelector('header > div > span.name')
+    || document.querySelector('header span.name')
+    || document.querySelector('header .name')
+    || document.querySelector('.user_info .name');
+  return (el?.innerText || '').trim();
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #333

SWEA(SW Expert Academy)에서 Pass 제출 후 GitHub 자동 업로드가 실패하던 문제를 수정했습니다.

주요 원인은 SWEA 결과 페이지 DOM 변경으로 인해 `parseData()`가 제출 정보를 제대로 파싱하지 못하는 상황에서도 업로드 로딩 UI가 먼저 표시되고, 이후 10초 타임아웃으로 빨간 체크가 표시되는 흐름이었습니다.

<img width="1805" height="1392" alt="KakaoTalk_Photo_2026-05-20-20-23-02" src="https://github.com/user-attachments/assets/3f5f2baa-03d5-47d1-bccf-054962cf7043" />
<img width="1805" height="1392" alt="KakaoTalk_Photo_2026-05-20-20-23-07" src="https://github.com/user-attachments/assets/a91525f1-d0b9-4a8f-a0f3-96d5e251511d" />

_수정 전 이슈 발생 모습 캡처본. 코드 제출 후 저장소 푸시 과정에서 약 10초 후 빨간 체크표시만 보였습니다._

## Changes

- SWEA 제출 결과 파싱에 selector fallback을 추가해 DOM 변경에 더 견고하게 대응
- 닉네임, 문제 번호, `contestProbId`, 제출 정보, 제출 일시 파싱을 null-safe하게 개선
- `problemId` 조회 실패 시 `contestProbId`로 저장된 SWEA 코드 데이터를 재조회하는 fallback 추가
- 파싱 결과가 유효할 때만 업로드 로딩 UI를 시작하도록 수정
- GitHub hook/token/stats가 준비되지 않은 경우 예외 대신 명확한 실패 로그와 실패 UI로 처리
- `getObjectDatafromPath()`에 null 가드를 추가해 hook 미설정 상태에서 발생하던 `.replace` 예외 방지
- SWEA 업로드 UI 삽입 위치와 완료/실패 마킹 함수에 null-safe 처리 추가

## Verification

- 수정된 js 파일들에 대해 `node --check` 수행.
- 로컬 브라우저에서 수정 작업이 완료된 BaekjoonHub 프로젝트를 압축해제된 확장 프로그램으로 로드 후 검증, SWEA Pass 제출 후 GitHub 업로드 및 초록 체크 표시 확인

<img width="1624" height="975" alt="스크린샷 2026-05-20 오후 9 33 44" src="https://github.com/user-attachments/assets/3a8721fb-f0b2-453d-8bc7-dece4defe3ba" />

_업로드가 정상적으로 수행됩니다. 
개발자도구 console 에서 저장소/토큰/stats가 준비되지 않아 업로드를 진행하지 못했다는 에러 로그는 테스트 당시 백준 허브 확장 프로그램이 2개 실행되고 있었고(원본, 수정본), 수정본 브라우저 확장 로컬 스토리지에는 hook/token 값이 저장되어 있지 않았기 때문에 발생합니다._

<img width="768" height="659" alt="스크린샷 2026-05-20 오후 9 47 20" src="https://github.com/user-attachments/assets/89cdeca1-85ea-42e4-a8ba-18c7ec649a25" />

_테스트 당시의 2개(원본, 수정본)의 백준 허브 확장 프로그램 로컬 스토리지가 배치되어 있는 모습_

<img width="1624" height="975" alt="스크린샷 2026-05-20 오후 9 34 32" src="https://github.com/user-attachments/assets/f0200955-7ddc-4eb9-9106-cba84e1ddc1b" />
<img width="1624" height="975" alt="스크린샷 2026-05-20 오후 9 35 03" src="https://github.com/user-attachments/assets/bee764ed-237f-4d75-8fda-fd02d22b6858" />

_연결된 GitHub 저장소에 정상적으로 풀이한 문제가 업로드 된 모습_

## Notes

- 백준/프로그래머스 업로드 로직과 GitHub API 커밋 로직은 수정하지 않았습니다.