### PR TITLE
fix: 프로그래머스 Bulk Upload 난이도 폴더 불일치 및 중복 업로드 수정

### DIFF
--- a/scripts/programmers/parsing.js
+++ b/scripts/programmers/parsing.js
@@ -163,7 +163,7 @@ async function findAllSolvedProblems() {
       problems.push({
         problemId: String(item.id),
         title: item.title,
-        level: `lv${item.level}`,
+        level: String(item.level),
       });
     }
     if (page >= data.totalPages) break;

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -329,7 +329,7 @@ function _baekjoonRankRemoverFilter(path) {
  * @returns {string} - 레벨과 관련된 경로를 제거한 문자열
  */
 function _programmersRankRemoverFilter(path) {
-  return path.replace(/\/(lv[0-9]|unrated)\//g, '/');
+  return path.replace(/\/(lv?[0-9]|unrated)\//g, '/');
 }
 
 /**

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -329,7 +329,7 @@ function _baekjoonRankRemoverFilter(path) {
  * @returns {string} - 레벨과 관련된 경로를 제거한 문자열
  */
 function _programmersRankRemoverFilter(path) {
-  return path.replace(/\/(lv?[0-9]|unrated)\//g, '/');
+  return path.replace(/\/((?:lv)?[0-9]|unrated)\//g, '/');
 }
 
 /**


### PR DESCRIPTION
## 문제 상황
프로그래머스 문제를 업로드하는 방식에 따라 생성되는 폴더 경로가 달라지는 버그가 있었습니다.
<br class="Apple-interchange-newline">
업로드 방식 | 생성 폴더
-- | --
문제 채점 후 개별 업로드 | 프로그래머스/1/문제번호. 제목/
전체제출 Bulk Upload | 프로그래머스/lv1/문제번호. 제목


## 수정 사항

1. scripts/programmers/parsing.js
findAllSolvedProblems()에서 level 값의 "lv" 접두사 제거 — 개별 업로드와 동일한 순수 숫자 형태로 통일

```ts
// Before
level: `lv${item.level}`,

// After
level: String(item.level),
```

2. scripts/storage.js

_programmersRankRemoverFilter 정규식을 확장하여 "1" 형태의 level 폴더도 경로에서 제거

```ts
// Before
return path.replace(/\/(lv[0-9]|unrated)\//g, '/');

// After
return path.replace(/\/(lv?[0-9]|unrated)\//g, '/');
```