### PR TITLE
fix: welcome.js 의 빈 레포 초기화가 sha 없는 PUT 으로 422 누적시키던 문제 수정 (#341)

### DIFF
--- a/welcome.js
+++ b/welcome.js
@@ -120,17 +120,43 @@ const linkStatusCode = (status, name) => {
   return bool;
 };
 
-/** Initialize empty repo with README.md */
+/**
+ * 빈 레포에 README.md 를 생성한다.
+ *
+ * 호출 측의 `res.size === 0` 만으로는 빈 레포 판정이 불안정하다. GitHub API 의
+ * `repo.size` 는 비동기 통계라 `auto_init: true` 로 생성된 직후의 레포는 README 가
+ * 이미 있어도 한동안 0 으로 응답한다. 그 윈도 안에 이 함수가 호출되면 이미 존재하는
+ * README 에 sha 없이 PUT 하여 422 가 떨어지고, `console.error(..., err)` 로 객체를
+ * 그대로 두 번째 인자에 넘기면 Chrome 확장 오류 패널이 toString 직렬화하여
+ * `Failed to initialize empty repo: [object Object]` 가 누적된다 (#341).
+ *
+ * 1차로 README 가 실제로 있는지 GET 으로 확인하고, 없을 때만 PUT 한다. probe ~ PUT
+ * 사이의 동시 생성 race 로 떨어지는 422 도 무시한다.
+ */
 const initializeEmptyRepoWelcome = async (token, hook, branch) => {
   const headers = { Authorization: `token ${token}`, Accept: 'application/vnd.github.v3+json', 'content-type': 'application/json' };
+  const probeUrl = `https://api.github.com/repos/${hook}/contents/README.md?ref=${encodeURIComponent(branch)}`;
+  const probe = await fetch(probeUrl, { headers });
+  if (probe.ok) {
+    // README 이미 존재 — 초기화 불필요.
+    return;
+  }
+  if (probe.status !== 404) {
+    const probeErr = await probe.json().catch(() => ({}));
+    console.error('Failed to probe README before empty-repo init:', probeErr.message || JSON.stringify(probeErr));
+    return;
+  }
+
   const repoName = hook.split('/')[1];
   const readmeContent = btoa(unescape(encodeURIComponent(`# ${repoName}\n${REPO_DESCRIPTION}\n`)));
   const res = await fetch(`https://api.github.com/repos/${hook}/contents/README.md`, {
     method: 'PUT', headers, body: JSON.stringify({ message: 'Initial commit - BaekjoonHub', content: readmeContent, branch }),
   });
   if (!res.ok) {
-    const err = await res.json();
-    console.error('Failed to initialize empty repo:', err);
+    const err = await res.json().catch(() => ({}));
+    // probe ~ PUT 사이의 동시 생성 race 로 이미 README 가 만들어진 경우(422 "sha wasn't supplied") 는 noop.
+    if (res.status === 422 && /sha/i.test(err.message || '')) return;
+    console.error('Failed to initialize empty repo:', err.message || JSON.stringify(err));
   }
 };
 


### PR DESCRIPTION
## Summary

Fixes #341.

`welcome.js` 의 `linkRepo` 에서 `res.size === 0` 분기로 `initializeEmptyRepoWelcome` 를 부르고, 이 함수가 sha 없이 README.md 에 PUT 하면서 422 가 떨어지는 문제를 수정합니다.

GitHub API 의 `repo.size` 는 비동기 통계라 `auto_init: true` 로 만든 새 레포는 README 가 있어도 한동안 0 을 반환하는 윈도가 있습니다. 그 윈도 안에 옵션 페이지에서 link 가 진입하면 위 경로를 타고 422 가 떨어지고, `console.error('Failed to initialize empty repo:', err)` 가 객체를 그대로 두 번째 인자에 넘기는 바람에 Chrome 확장 오류 패널이 toString 직렬화하여 `Failed to initialize empty repo: [object Object]` 가 매번 누적되어 진짜 에러를 가리고 있었습니다.

## Changes

- `initializeEmptyRepoWelcome` 에 README 사전 probe(GET `/contents/README.md`)를 추가하여 실제로 없을 때만 PUT 합니다.
- probe ~ PUT 사이의 동시 생성 race 로 떨어지는 422 + `"sha wasn't supplied"` 는 noop 처리합니다.
- 실패 로그를 객체 그대로 두 번째 인자로 넘기지 않고 `err.message` 또는 `JSON.stringify(err)` 로 직렬화하여, 확장 오류 패널에도 의미 있는 메시지가 남도록 합니다.

호출 측 `linkRepo` 의 `res.size === 0` 가드는 fast-path 로 유지 — 정상 케이스에서는 추가 API 호출이 발생하지 않습니다. 가드를 통과한 "혹시 빈 레포일지도" 케이스에서만 probe 1번이 추가됩니다.

## Verification

### 422 응답 재현 (수정 전 동작)

`auto_init: true` 로 만든 새 레포에 `repo.size === 0` 윈도가 60초 이상 유지됨을 실측:

| 시점 | `repo.size` | README sha (`/contents/README.md`) |
| --- | --- | --- |
| immediate | 0 | `30e86ef5...` (200) |
| t+10s | 0 | (변화 없음) |
| t+30s | 0 | (변화 없음) |
| t+60s | 0 | (변화 없음) |

그 윈도 안에 sha 없이 PUT:

```
HTTP/1.1 422 Unprocessable Entity
{
  "message": "Invalid request.\n\n\"sha\" wasn't supplied.",
  "documentation_url": "https://docs.github.com/rest/repos/contents#create-or-update-file-contents",
  "status": "422"
}
```

대조군 (sha 포함) → `HTTP 200`.

### 수정 후

같은 레포에 대해 새 로직 시뮬레이션 (curl):

- probe `GET /contents/README.md?ref=master` → `HTTP 200`
- 새 로직은 `probe.ok === true` 에서 early return → PUT 미호출 → `console.error` 미호출 → 확장 오류 패널 `[object Object]` 누적 없음

### 테스트 환경

- 대상 커밋: `db3d74c` (= v1.4.14)
- OS: Windows 11
- Node syntax check: `node --check welcome.js` 통과

## Notes

- 본 수정은 옵션 페이지(`welcome.js`) 범위로 한정되며 다른 플랫폼(`scripts/baekjoon`, `scripts/programmers`, `scripts/swexpertacademy`)의 코드 경로에는 영향이 없습니다.
- 동일 사용자 환경에서 함께 보고된 SWEA 연속 업로드 실패(#340) 는 본 PR 의 root cause 와 코드 경로가 다른 별개 이슈로, 별도로 추적됩니다.
